### PR TITLE
Update define.amd of dummy define to be an object

### DIFF
--- a/compilers/amd.js
+++ b/compilers/amd.js
@@ -346,6 +346,6 @@ exports.compile = function(load, normalize, loader) {
   // because we've blindly replaced the define statement from AMD with a System.register call
   // we have to ensure we still trigger any AMD guard statements in the code by creating a dummy define which isn't called
   return Promise.resolve({
-    source: '(function() {\nfunction define(){};  define.amd = true;\n  ' + output.js.replace(/\n/g, '\n  ') + '})();'
+    source: '(function() {\nfunction define(){};  define.amd = {};\n  ' + output.js.replace(/\n/g, '\n  ') + '})();'
   });
 }


### PR DESCRIPTION
**before:**

``` JavaScript
function define(){};  define.amd = true;
```

**after**

``` JavaScript
function define(){};  define.amd = {};
```

**Reasoning:** both require.js and `System.amdDefine` expose `.amd` property as an `Object` and that would be expected sometimes for UMD wrappers like that one `lodash` uses:

``` JavaScript
if (typeof define == 'function' && typeof define.amd == 'object' && define.amd) {
  // ...
}
```

And "normal/simplified" wrappers wouldn't be affected.
