### PR TITLE
fix: System.register __filename format on windows boxes

### DIFF
--- a/compilers/cjs.js
+++ b/compilers/cjs.js
@@ -30,7 +30,7 @@ CJSRequireTransformer.prototype.transformCallExpression = function(tree) {
 exports.CJSRequireTransformer = CJSRequireTransformer;
 
 function cjsOutput(name, deps, address, source, baseURL) {
-  var filename = path.relative(baseURL, address);
+  var filename = path.relative(baseURL, address).replace(/\\/g, "/");
   var dirname = path.dirname(filename);
   var output = 'System.register("' + name + '", ' + JSON.stringify(deps) + ', true, function(require, exports, module) {\n'
     + '  var global = System.global;\n'


### PR DESCRIPTION
on windows boxes when bundling with e.g. `jspm bundle main" then the following code gets generated ...

```
System.register("github:hammerjs/hammer.js@2.0.3", ["github:hammerjs/hammer.js@2.0.3/hammer"], true, function(require, exports, module) {
  var global = System.global;
  var __define = global.define;
  global.define = undefined;
  var __filename = "jspm_packages\github\hammerjs\hammer.js@2.0.3.js";
  var __dirname = "jspm_packages\github\hammerjs";
  module.exports = require("github:hammerjs/hammer.js@2.0.3/hammer");

  global.define = __define;
  return module.exports;
});
```

where the (unescaped, single) backslashes in `__filename` and `__dirname` (e.g. `"jspm_packages\github\hammerjs\hammer.js@2.0.3.js"`) lead to the following error in the browser ...

```
Uncaught SyntaxError: Unexpected token ILLEGAL
```

this PR just shows how this can be fixed. I don't know if my code is clean enough though or if this issue can be addressed by other means on the node.js side of things.
