### PR TITLE
Put sourcemap comment on new line at EOF

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -113,7 +113,7 @@ exports.writeOutputFile = function(opts, outputs) {
 
   if (opts.sourceMaps) {
     var sourceMapFile = path.basename(opts.outFile) + '.map';
-    output.source += '//# sourceMappingURL=' + sourceMapFile;
+    output.source += '\n//# sourceMappingURL=' + sourceMapFile;
   }
 
   return asp(mkdirp)(path.dirname(opts.outFile))


### PR DESCRIPTION
According to the [spec](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit#heading=h.lmz475t4mvbx) the source mapping comment should be placed on a new line at the end of the file. I've had problems with some sourcemaps not being picked up unless they were on their own line in the past.

I looked for tests to update for this but couldn't find any, would be good to have some eventually I guess!
