### PR TITLE
Fixup null error

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -99,7 +99,7 @@ function minify(output, outFile) {
     },
     source_map: sourceMap
   });
-  output.sourceMap = sourceMap.toString();
+  output.sourceMap = sourceMap && sourceMap.toString();
 
   return output;
 }


### PR DESCRIPTION
Looks like `--skip-source-maps` was broken in https://github.com/systemjs/builder/commit/b4ae08e7ad4770cfef2a4bca006248ce190fd399