### PR TITLE
Expose mangle config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ As well as an `options.config` parameter, it is also possible to specify minific
   builder.build('myModule', 'outfile.js', { minify: true, sourceMaps: true, config: cfg });
 ```
 
+Compile time with source maps can also be improved with the `lowResSourceMaps` option:
+
+```javascript
+  builder.build('myModule', 'outfile.js', { sourceMaps: true, lowResSourceMaps: true });
+```
+
 If you want minification without mangling, you can set the config like this:
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ As well as an `options.config` parameter, it is also possible to specify minific
   builder.build('myModule', 'outfile.js', { minify: true, sourceMaps: true, config: cfg });
 ```
 
+If you want minification without mangling, you can set the config like this:
+
+```javascript
+  var builder = require('systemjs-builder');
+  builder.build('myModule', 'outfile.js', { minify: true, mangle: false });
+```
+
 ### Ignore Resources
 
 If loading resources that shouldn't even be traced as part of the build (say an external import), these

--- a/compilers/amd.js
+++ b/compilers/amd.js
@@ -395,7 +395,7 @@ exports.compile = function(load, opts, loader) {
   var options = {};
   if (opts.sourceMaps)
     options.sourceMaps = 'memory';
-  if (opts.lowResolutionSourceMaps)
+  if (opts.lowResSourceMaps)
     options.lowResolutionSourceMap = true;
 
   if (load.metadata.sourceMap)

--- a/compilers/amd.js
+++ b/compilers/amd.js
@@ -373,8 +373,6 @@ exports.attach = function(loader) {
 };
 
 exports.remap = function(source, map, fileName) {
-  // NB can remove after Traceur 0.0.77
-  if (!source) source = ' ';
   var options = {script: true};
   var compiler = new traceur.Compiler(options);
   var tree = compiler.parse(source, fileName || '');

--- a/compilers/cjs.js
+++ b/compilers/cjs.js
@@ -78,7 +78,7 @@ exports.compile = function(load, opts, loader) {
   var options = { script: true };
   if (opts.sourceMaps)
     options.sourceMaps = 'memory';
-  if (opts.lowResolutionSourceMaps)
+  if (opts.lowResSourceMaps)
     options.lowResolutionSourceMap = true;
 
   if (load.metadata.sourceMap)

--- a/compilers/es6.js
+++ b/compilers/es6.js
@@ -38,7 +38,8 @@ exports.compile = function(load, opts, loader) {
   if (loader.parser == '6to5') {
     options = loader.to5Options || {};
     options.modules = 'system';
-    options.sourceMap = true;
+    if (opts.sourceMaps)
+      options.sourceMap = true;
     options.filename = load.address;
     options.filenameRelative = load.name;
     options.code = true;
@@ -54,8 +55,9 @@ exports.compile = function(load, opts, loader) {
     var output = to5.transform(source, options);
     
     source = output.code;
-    if (output.map)
+    if (output.map) {
       load.metadata.sourceMap = output.map;
+    }
   }
 
   // NB todo - create an inline 6to5 transformer to do import normalization

--- a/compilers/es6.js
+++ b/compilers/es6.js
@@ -67,7 +67,7 @@ exports.compile = function(load, opts, loader) {
 
   if (opts.sourceMaps)
     options.sourceMaps = 'memory';
-  if (opts.lowResolutionSourceMaps)
+  if (opts.lowResSourceMaps)
     options.lowResolutionSourceMap = true;
 
   if (load.metadata.sourceMap)

--- a/compilers/es6.js
+++ b/compilers/es6.js
@@ -44,8 +44,12 @@ exports.compile = function(load, opts, loader) {
     options.code = true;
     options.ast = false;
     options.moduleIds = true;
-    var output = to5.transform(source, options);
-
+    /* if (opts.runtime) {
+      options.optional = options.optional || [];
+      if (options.optional.indexOf('selfContained') == -1)
+        options.optional.push('selfContained')
+      var output = to5.transform(source, options);
+    } */
     source = output.code;
     if (output.map)
       load.metadata.sourceMap = output.map;

--- a/compilers/es6.js
+++ b/compilers/es6.js
@@ -44,12 +44,15 @@ exports.compile = function(load, opts, loader) {
     options.code = true;
     options.ast = false;
     options.moduleIds = true;
-    /* if (opts.runtime) {
+    /*
+    if (opts.runtime) {
       options.optional = options.optional || [];
       if (options.optional.indexOf('selfContained') == -1)
-        options.optional.push('selfContained')
-      var output = to5.transform(source, options);
-    } */
+        options.optional.push('selfContained') 
+    }
+    */
+    var output = to5.transform(source, options);
+    
     source = output.code;
     if (output.map)
       load.metadata.sourceMap = output.map;

--- a/compilers/global.js
+++ b/compilers/global.js
@@ -82,7 +82,7 @@ exports.compile = function(load, opts, loader) {
 
   if (opts.sourceMaps)
     options.sourceMaps = 'memory';
-  if (opts.lowResolutionSourceMaps)
+  if (opts.lowResSourceMaps)
     options.lowResolutionSourceMap = true;
 
   if (load.metadata.sourceMap)

--- a/index.js
+++ b/index.js
@@ -100,9 +100,9 @@ exports.buildTree = function(tree, outFile, opts) {
   return Promise.all(names.map(function(name) {
     var load = tree[name];
     return Promise.resolve(compileLoad(load, opts))
-                  .then(outputs.push.bind(outputs));
+    .then(outputs.push.bind(outputs));
   }))
-  .then(builder.writeOutputFile.bind(this, opts, outputs));
+  .then(builder.writeOutputFile.bind(this, opts, outputs, loader.baseURL));
 };
 
 exports.buildSFX = function(moduleName, outFile, opts) {
@@ -125,7 +125,7 @@ exports.buildSFX = function(moduleName, outFile, opts) {
       }
 
       return Promise.resolve(compileLoad(load, opts, compilers))
-                    .then(outputs.push.bind(outputs));
+      .then(outputs.push.bind(outputs));
     }));
   })
   // next add sfx headers for formats at the beginning
@@ -160,7 +160,7 @@ exports.buildSFX = function(moduleName, outFile, opts) {
   .then(function(result) {
     outputs.push("});");
   })
-  .then(builder.writeOutputFile.bind(this, opts, outputs));
+  .then(builder.writeOutputFile.bind(this, opts, outputs, loader.baseURL));
 };
 
 exports.loadConfig = function(configFile) {

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -51,17 +51,14 @@ function processOutputs(outputs) {
   return outputObj;
 }
 
-function createOutput(outputs, outFile, createSourceMaps) {
-  var outPath = path.dirname(outFile);
-
+function createOutput(outputs, outFile, baseURL, createSourceMaps) {
   // process output
   var sourceMap;
 
   var outputObj = processOutputs(outputs);
 
   if (createSourceMaps && outputObj.sourceMapsWithOffsets.length)
-    sourceMap = saucy.concatenateSourceMaps(outFile, outputObj.sourceMapsWithOffsets, 
-        'file:' + path.resolve(outPath));
+    sourceMap = saucy.concatenateSourceMaps(outFile, outputObj.sourceMapsWithOffsets, baseURL);
   
   var output = outputObj.sources.join('\n');
 
@@ -71,9 +68,7 @@ function createOutput(outputs, outFile, createSourceMaps) {
   };
 }
 
-function minify(output, outFile, mangle) {
-  var fileName = path.basename(outFile);
-
+function minify(output, fileName, mangle) {
   var ast = uglify.parse(output.source, { filename: fileName });
   ast.figure_out_scope();
   ast = ast.transform(uglify.Compressor({ warnings: false }));
@@ -101,14 +96,19 @@ function minify(output, outFile, mangle) {
     },
     source_map: sourceMap
   });
-  output.sourceMap = sourceMap && sourceMap.toString();
+  output.sourceMap = sourceMap;
 
   return output;
 }
 
 
-exports.writeOutputFile = function(opts, outputs) {
-  var output = createOutput(outputs, opts.outFile, opts.sourceMaps);
+exports.writeOutputFile = function(opts, outputs, baseURL) {
+  // remove 'file:' part
+  var basePath = baseURL.substr(5);
+
+  opts.outFile = path.relative(basePath, path.resolve(opts.outFile));
+
+  var output = createOutput(outputs, opts.outFile, baseURL, opts.sourceMaps);
 
   if (opts.minify)
     output = minify(output, opts.outFile, opts.mangle);
@@ -118,14 +118,14 @@ exports.writeOutputFile = function(opts, outputs) {
     output.source += '\n//# sourceMappingURL=' + sourceMapFile;
   }
 
-  return asp(mkdirp)(path.dirname(opts.outFile))
+  return asp(mkdirp)(path.dirname(path.resolve(basePath, opts.outFile)))
   .then(function() {
     if (!opts.sourceMaps)
       return;
-    return asp(fs.writeFile)(path.resolve(path.dirname(opts.outFile), sourceMapFile), output.sourceMap);
+    return asp(fs.writeFile)(path.resolve(basePath, path.dirname(opts.outFile), sourceMapFile), output.sourceMap);
   })
   .then(function() {
-    return asp(fs.writeFile)(opts.outFile, output.source);
+    return asp(fs.writeFile)(path.resolve(basePath, opts.outFile), output.source);
   });
 
 };

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -71,7 +71,7 @@ function createOutput(outputs, outFile, createSourceMaps) {
   };
 }
 
-function minify(output, outFile) {
+function minify(output, outFile, mangle) {
   var fileName = path.basename(outFile);
 
   var ast = uglify.parse(output.source, { filename: fileName });
@@ -79,9 +79,11 @@ function minify(output, outFile) {
   ast = ast.transform(uglify.Compressor({ warnings: false }));
   ast.figure_out_scope();
   ast.compute_char_frequency();
-  ast.mangle_names({
-    except: ['require']
-  });
+  if (mangle !== false) {
+    ast.mangle_names({
+      except: ['require']
+    });
+  }
 
   var sourceMap;
   if (output.sourceMap)
@@ -109,7 +111,7 @@ exports.writeOutputFile = function(opts, outputs) {
   var output = createOutput(outputs, opts.outFile, opts.sourceMaps);
 
   if (opts.minify)
-    output = minify(output, opts.outFile);
+    output = minify(output, opts.outFile, opts.mangle);
 
   if (opts.sourceMaps) {
     var sourceMapFile = path.basename(opts.outFile) + '.map';

--- a/lib/sourcemaps.js
+++ b/lib/sourcemaps.js
@@ -2,8 +2,6 @@ var sourceMap = require('source-map');
 var traceur = require('traceur');
 var path = require('path');
 
-var isWin = process.platform.match(/^win/);
-
 var wrapSourceMap = function(map) {
   return new sourceMap.SourceMapConsumer(map);
 };
@@ -13,29 +11,30 @@ exports.removeSourceMaps = function(source) {
   return source.replace(sourceMapRegEx, '');
 };
 
-exports.concatenateSourceMaps = function(sourceFilename, mapsWithOffsets, outPath) {
+function getMapObject(map) {
+  if (typeof map != 'string')
+    return map;
+
+  try {
+    return JSON.parse(map);
+  }
+  catch(error) {
+    throw new Error('Invalid JSON: ' + map);
+  }
+}
+
+exports.concatenateSourceMaps = function(sourceFilename, mapsWithOffsets, baseURL) {
   var generated = new sourceMap.SourceMapGenerator({
     file: sourceFilename
   });
 
   mapsWithOffsets.forEach(function(pair) {
     var offset = pair[0];
-    var mapSource = pair[1];
-    var map = mapSource;
-    if (typeof mapSource == 'string')
-      try {
-        map = JSON.parse(mapSource);
-      } catch (error) {
-        throw new Error(mapSource + ": Invalid JSON");
-      }
-
-    // this is odd, sourceRoot is redundant (and causes doubling)
-    map.sourceRoot = '';
+    var map = getMapObject(pair[1]);
 
     wrapSourceMap(map).eachMapping(function(mapping) {
-      if (mapping.source.match(/^@traceur/)) {
+      if (mapping.source.match(/\/@traceur/))
         return;
-      }
 
       generated.addMapping({
         generated: {
@@ -53,18 +52,11 @@ exports.concatenateSourceMaps = function(sourceFilename, mapsWithOffsets, outPat
     });
   });
 
-  if (outPath) {
-    // convert from library internals format to canonical
-    var normalized = JSON.parse(JSON.stringify(generated));
-    // convert paths to relative
-    normalized.sources = normalized.sources.map(function(source) {
-      if (isWin)
-        return path.relative(outPath, source).replace(/\\/g, '/');
-      else
-        return path.relative(outPath, source);
-    });
-    return JSON.stringify(normalized);
-  }
-
-  return generated.toString();
+  // convert from library internals format to canonical
+  var normalized = JSON.parse(JSON.stringify(generated));
+  // convert paths to relative
+  normalized.sources = normalized.sources.map(function(source) {
+    return path.relative(baseURL, source).replace(/\\/g, '/');
+  });
+  return JSON.stringify(normalized);
 };

--- a/test/test-build.html
+++ b/test/test-build.html
@@ -14,7 +14,7 @@
     <div id="qunit-test-area"></div>
 
     <script src="../node_modules/es6-module-loader/dist/es6-module-loader.js"></script>
-    <script src="../node_modules/systemjs/dist/system-csp.js" type="text/javascript"></script>
+    <script src="../node_modules/systemjs/dist/system.js" data-traceur-runtime-src="../node_modules/traceur/bin/traceur.js" type="text/javascript"></script>
 
     <script src="../bower_components/qunit/qunit/qunit.js"></script>
 
@@ -29,7 +29,7 @@
         });
       }
 
-      System.paths['jquery-cdn'] = 'https://code.jquery.com/jquery-2.1.1.min.js';
+      System.paths['jquery-cdn'] = 'https://github.jspm.io/components/jquery@2.1.3/jquery.js';
 
       System.bundles['tree-build'] = ['tree/third', 'tree/cjs', 'tree/jquery', 'tree/second', 'tree/global', 'tree/amd', 'tree/first'];
       System.bundles['umd'] = ['tree/umd'];

--- a/test/tree/first.js
+++ b/test/tree/first.js
@@ -5,3 +5,8 @@ import './amd';
 import './component.jsx!./jsx';
 
 export var p = 5;
+export class test {
+  constructor() {
+    super();
+  }
+}


### PR DESCRIPTION
This allows to set `minify: true, mangle: false` in config. `mangle` defaults to `true` to not break bc.
This is needed if you use angular and want to use Implicit Annotation e.g.

Being able to remove whitespace and comments during the build is probably still desirable.