### PR TITLE
expose mangle option, allows for minifying without mangling

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ Compile time with source maps can also be improved with the `lowResSourceMaps` o
   builder.build('myModule', 'outfile.js', { sourceMaps: true, lowResSourceMaps: true });
 ```
 
+If you want minification without mangling, you can set the config like this:
+
+```javascript
+  var builder = require('systemjs-builder');
+  builder.build('myModule', 'outfile.js', { minify: true, mangle: false });
+```
+
 ### Ignore Resources
 
 If loading resources that shouldn't even be traced as part of the build (say an external import), these

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -68,15 +68,17 @@ function createOutput(outputs, outFile, baseURL, createSourceMaps) {
   };
 }
 
-function minify(output, fileName) {
+function minify(output, fileName, mangle) {
   var ast = uglify.parse(output.source, { filename: fileName });
   ast.figure_out_scope();
   ast = ast.transform(uglify.Compressor({ warnings: false }));
   ast.figure_out_scope();
   ast.compute_char_frequency();
-  ast.mangle_names({
-    except: ['require']
-  });
+  if (mangle !== false) {
+    ast.mangle_names({
+      except: ['require']
+    });
+  }
 
   var sourceMap;
   if (output.sourceMap)
@@ -109,7 +111,7 @@ exports.writeOutputFile = function(opts, outputs, baseURL) {
   var output = createOutput(outputs, opts.outFile, baseURL, opts.sourceMaps);
 
   if (opts.minify)
-    output = minify(output, opts.outFile);
+    output = minify(output, opts.outFile, opts.mangle);
 
   if (opts.sourceMaps) {
     var sourceMapFile = path.basename(opts.outFile) + '.map';


### PR DESCRIPTION
This PR is the same as #57 without the rebase mess.

This allows to set minify: true, mangle: false in config. mangle defaults to true to not break bc.
This is needed if you use angular and want to use Implicit Annotation e.g.

Being able to remove whitespace and comments during the build is probably still desirable.