### PR TITLE
Output to memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test/excluded.js
 test/sfx.js
 test/tree-build.js
 test/tree-build.js.map
+test/memory-test

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ exports.buildTree = function(tree, outFile, opts) {
     return Promise.resolve(compileLoad(load, opts))
     .then(outputs.push.bind(outputs));
   }))
-  .then(builder.writeOutputFile.bind(this, opts, outputs, loader.baseURL));
+  .then(builder.writeOutput.bind(this, opts, outputs, loader.baseURL));
 };
 
 exports.buildSFX = function(moduleName, outFile, opts) {
@@ -162,7 +162,7 @@ exports.buildSFX = function(moduleName, outFile, opts) {
     outputs.push("});");
   })
   .then(function() {
-    return builder.writeOutputFile(opts, outputs, loader.baseURL);
+    return builder.writeOutput(opts, outputs, loader.baseURL);
   });
 };
 

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -2,7 +2,8 @@ var saucy = require('./sourcemaps');
 var path = require('path');
 var mkdirp = require('mkdirp');
 var fs = require('fs');
-var asp = require('rsvp').denodeify;
+var rsvp = require('rsvp');
+var asp = rsvp.denodeify;
 var uglify = require('uglify-js');
 
 function countLines(str) {
@@ -36,7 +37,7 @@ function processOutputs(outputs) {
       if (map) {
         sourceMapsWithOffsets.push([offset + offset_, map]);
       }
-    } 
+    }
     else if (typeof output == 'string') {
       source = output;
     }
@@ -59,7 +60,7 @@ function createOutput(outputs, outFile, baseURL, createSourceMaps) {
 
   if (createSourceMaps && outputObj.sourceMapsWithOffsets.length)
     sourceMap = saucy.concatenateSourceMaps(outFile, outputObj.sourceMapsWithOffsets, baseURL);
-  
+
   var output = outputObj.sources.join('\n');
 
   return {
@@ -101,18 +102,7 @@ function minify(output, fileName, mangle) {
   return output;
 }
 
-
-exports.writeOutputFile = function(opts, outputs, baseURL) {
-  // remove 'file:' part
-  var basePath = baseURL.substr(5);
-
-  opts.outFile = path.relative(basePath, path.resolve(opts.outFile));
-
-  var output = createOutput(outputs, opts.outFile, baseURL, opts.sourceMaps);
-
-  if (opts.minify)
-    output = minify(output, opts.outFile, opts.mangle);
-
+function writeOutputFile(opts, output, basePath) {
   if (opts.sourceMaps) {
     var sourceMapFile = path.basename(opts.outFile) + '.map';
     output.source += '\n//# sourceMappingURL=' + sourceMapFile;
@@ -120,12 +110,36 @@ exports.writeOutputFile = function(opts, outputs, baseURL) {
 
   return asp(mkdirp)(path.dirname(path.resolve(basePath, opts.outFile)))
   .then(function() {
-    if (!opts.sourceMaps)
-      return;
-    return asp(fs.writeFile)(path.resolve(basePath, path.dirname(opts.outFile), sourceMapFile), output.sourceMap);
+    if (!opts.sourceMaps) return;
+    var sourceMapPath = path.resolve(basePath, path.dirname(opts.outFile), sourceMapFile);
+    return asp(fs.writeFile)(sourceMapPath, output.sourceMap);
   })
   .then(function() {
-    return asp(fs.writeFile)(path.resolve(basePath, opts.outFile), output.source);
+    var sourcePath = path.resolve(basePath, opts.outFile);
+    return asp(fs.writeFile)(sourcePath, output.source);
   });
+}
 
+exports.inlineSourceMap = function(output) {
+  return output.source +
+    '\n//# sourceMappingURL=data:application/json;base64,' +
+    new Buffer(output.sourceMap.toString()).toString('base64');
+};
+
+exports.writeOutput = function(opts, outputs, baseURL) {
+  // remove 'file:' part
+  var basePath = baseURL.substr(5);
+
+  if (opts.outFile)
+    opts.outFile = path.relative(basePath, path.resolve(opts.outFile));
+
+  var output = createOutput(outputs, opts.outFile, baseURL, opts.sourceMaps);
+
+  if (opts.minify)
+    output = minify(output, opts.outFile, opts.mangle);
+
+  if (opts.outFile)
+    return writeOutputFile(opts, output, basePath);
+  else
+    return rsvp.resolve(output);
 };

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -92,7 +92,7 @@ function minify(output, fileName, mangle) {
     ascii_only: true,
     // keep first comment
     comments: function(node, comment) {
-      return comment.line == 1 && comment.col == 0;
+      return comment.line === 1 && comment.col === 0;
     },
     source_map: sourceMap
   });

--- a/test/run-build.js
+++ b/test/run-build.js
@@ -1,10 +1,23 @@
 var builder = require('../index');
+var inline = require('../lib/builder').inlineSourceMap;
+var fs = require('fs');
 
 var err = function(e) {
   setTimeout(function() {
     throw e;
   });
-}
+};
+
+console.log('Running in-memory build...');
+builder.loadConfig('./cfg.js')
+.then(function() {
+  builder.build('tree/first', null, { sourceMaps: true, minify: true })
+  .then(function(output) {
+    fs.writeFile('memory-test', inline(output));
+    console.log('Wrote in-memory build to ./memory-test');
+  })
+  .catch(err);
+});
 
 console.log('Running a multi-format build...');
 

--- a/test/run-build.js
+++ b/test/run-build.js
@@ -51,55 +51,55 @@ builder.loadConfig('./cfg.js')
   .then(function() {
     return builder.trace('tree/amd-1').then(function(trace) {
       return builder.buildTree(builder.subtractTrees(trace.tree, treeFirst), 'amd-1.js');
-    })
+    });
   })
 
   .then(function() {
     return builder.trace('tree/amd-2').then(function(trace) {
       return builder.buildTree(builder.subtractTrees(trace.tree, treeFirst), 'amd-2.js');
-    })
+    });
   })
 
   .then(function() {
     return builder.trace('tree/amd-3').then(function(trace) {
       return builder.buildTree(builder.subtractTrees(trace.tree, treeFirst), 'amd-3.js');
-    })
+    });
   })
 
   .then(function() {
     return builder.trace('tree/amd-4').then(function(trace) {
       return builder.buildTree(builder.subtractTrees(trace.tree, treeFirst), 'amd-4.js');
-    })
+    });
   })
 
   .then(function() {
     return builder.trace('tree/amd-5a').then(function(trace) {
       return builder.buildTree(builder.subtractTrees(trace.tree, treeFirst), 'amd-5a.js');
-    })
+    });
   })
 
   .then(function() {
     return builder.trace('tree/amd-5b').then(function(trace) {
       return builder.buildTree(builder.subtractTrees(trace.tree, treeFirst), 'amd-5b.js');
-    })
+    });
   })
 
   .then(function() {
     return builder.trace('tree/amd-6a').then(function(trace) {
       return builder.buildTree(builder.subtractTrees(trace.tree, treeFirst), 'amd-6a.js');
-    })
+    });
   })
 
   .then(function() {
     return builder.trace('tree/amd-6b').then(function(trace) {
       return builder.buildTree(builder.subtractTrees(trace.tree, treeFirst), 'amd-6b.js');
-    })
+    });
   })
 
   .then(function() {
     return builder.trace('tree/umd').then(function(trace) {
       return builder.buildTree(builder.subtractTrees(trace.tree, treeFirst), 'umd.js');
-    })
+    });
   })
 
   .then(function() {


### PR DESCRIPTION
@guybedford let me know if you're happy with this approach, most notably the API (return file-contents string within promise). 

Perhaps a stream is more suitable, and I'm not sure what was meant by "memory FS". Looked at things like https://github.com/tschaub/mock-fs, but that sort of evil seems doesn't seem to belong outside of testing, and not sure the value it would add in the scenario vs return an inlined-file or a dictionary of the separate files.

Need to hook up Uglify for in-memory usage, and refactor my goop (been a while, JavaScript)

Closes #54 