### PR TITLE
reverting deletion of filenameRelative from es6 compiler

### DIFF
--- a/compilers/es6.js
+++ b/compilers/es6.js
@@ -42,7 +42,7 @@ exports.compile = function(load, opts, loader) {
     options.filename = load.address;
     options.code = true;
     options.ast = false;
-    options.moduleIds = true;
+    // options.moduleIds = true;
 
     if (normalize)
       options.resolveModuleSource = function(dep) {


### PR DESCRIPTION
Fixes https://github.com/systemjs/builder/issues/77, see commit comment for details.