### PR TITLE
clean up indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,36 +32,36 @@ Usage
 ### Install
 
 ```javascript
-  npm install systemjs-builder
+npm install systemjs-builder
 ```
 
 ### Basic Use
 
 ```javascript
-  var path = require("path");
-  var Builder = require('systemjs-builder');
+var path = require("path");
+var Builder = require('systemjs-builder');
+
+var builder = new Builder({
+  baseURL: path.resolve('some/folder'),
+
+  // any map config
+  map: {
+    jquery: 'jquery-1.2.3/jquery'
+  },
   
-  var builder = new Builder({
-    baseURL: path.resolve('some/folder'),
+  // opt in to Babel for transpiling over Traceur
+  transpiler: 'babel'
 
-    // any map config
-    map: {
-      jquery: 'jquery-1.2.3/jquery'
-    },
-    
-    // opt in to Babel for transpiling over Traceur
-    transpiler: 'babel'
-
-    // etc. any SystemJS config
-  })
-  .build('myModule', 'outfile.js')
-  .then(function() {
-    console.log('Build complete');
-  })
-  .catch(function(err) {
-    console.log('Build error');
-    console.log(err);
-  });
+  // etc. any SystemJS config
+})
+.build('myModule', 'outfile.js')
+.then(function() {
+  console.log('Build complete');
+})
+.catch(function(err) {
+  console.log('Build error');
+  console.log(err);
+});
 ```
 
 ### Setting Configuration
@@ -75,14 +75,14 @@ System.config({ ... });
 Then we can load this config file through the builder:
 
 ```javascript
-  // `builder.loadConfig` will load config from a file
-  builder.loadConfig('./cfg.js')
-  .then(function() {
-    // additional config can also be set through `builder.config`
-    builder.config({ baseURL: 'file:' + process.cwd() });
+// `builder.loadConfig` will load config from a file
+builder.loadConfig('./cfg.js')
+.then(function() {
+  // additional config can also be set through `builder.config`
+  builder.config({ baseURL: 'file:' + process.cwd() });
 
-    return builder.build('myModule', 'outfile.js');
-  });
+  return builder.build('myModule', 'outfile.js');
+});
 
 ```
 
@@ -96,7 +96,7 @@ To reset the loader state and configuration use `builder.reset()`.
 To make a bundle that is independent of the SystemJS loader entirely, we can make SFX bundles:
 
 ```javascript
-  builder.buildSFX('myModule', 'outfile.js', options);
+builder.buildSFX('myModule', 'outfile.js', options);
 ```
 
 This bundle file can then be included with a `<script>` tag, and no other dependencies (apart from Traceur or Babel runtime if needed) would need to be included in the page.
@@ -107,7 +107,7 @@ Rather, if it is needed to have globals like `jQuery` not included, as they will
 
 jquery.js
 ```javascript
-  module.exports = window.jQuery;
+module.exports = window.jQuery;
 ```
 
 ### Minfication & Source Maps
@@ -115,19 +115,19 @@ jquery.js
 As well as an `options.config` parameter, it is also possible to specify minification and source maps options:
 
 ```javascript
-  builder.build('myModule', 'outfile.js', { minify: true, sourceMaps: true, config: cfg });
+builder.build('myModule', 'outfile.js', { minify: true, sourceMaps: true, config: cfg });
 ```
 
 Compile time with source maps can also be improved with the `lowResSourceMaps` option:
 
 ```javascript
-  builder.build('myModule', 'outfile.js', { sourceMaps: true, lowResSourceMaps: true });
+builder.build('myModule', 'outfile.js', { sourceMaps: true, lowResSourceMaps: true });
 ```
 
 If you want minification without mangling, you can set the config like this:
 
 ```javascript
-  builder.build('myModule', 'outfile.js', { minify: true, mangle: false });
+builder.build('myModule', 'outfile.js', { minify: true, mangle: false });
 ```
 
 ### Ignore Resources
@@ -154,25 +154,25 @@ Tree operations include `addTrees`, `subtractTrees`, `intersectTrees` and `extra
 In this example we build `app/core` excluding `app/corelibs`:
 
 ```javascript
-  var Builder = require('systemjs-builder');
-  
-  var builder = new Builder({
-    baseURL: '...',
-    map: {
-    } // etc. config
-  });
+var Builder = require('systemjs-builder');
 
-  builder.trace('app/main')
-  .then(function(appTrace) {
+var builder = new Builder({
+  baseURL: '...',
+  map: {
+  } // etc. config
+});
 
-    return builder.trace('app/corelibs')
-    .then(function(coreTrace) {
-      return builder.subtractTrees(appTrace.tree, coreTrace.tree);
-    });
-  })
-  .then(function(appMinusCoreTree) {
-    return builder.buildTree(appMinusCoreTree, 'output-file.js', { minify: true, sourceMaps: true });
+builder.trace('app/main')
+.then(function(appTrace) {
+
+  return builder.trace('app/corelibs')
+  .then(function(coreTrace) {
+    return builder.subtractTrees(appTrace.tree, coreTrace.tree);
   });
+})
+.then(function(appMinusCoreTree) {
+  return builder.buildTree(appMinusCoreTree, 'output-file.js', { minify: true, sourceMaps: true });
+});
 ```
 
 #### Example - Common Libraries
@@ -180,35 +180,35 @@ In this example we build `app/core` excluding `app/corelibs`:
 In this example we build `app/first` and `app/second` creating a separate `app/shared` library:
 
 ```javascript
-  var Builder = require('systemjs-builder');
-  
-  var builder = new Builder({
-    // ...
-  });
+var Builder = require('systemjs-builder');
 
-  var firstTree, secondTree, commonTree;
+var builder = new Builder({
+  // ...
+});
 
-  builder.trace('app/first')
-  .then(function(trace) {
-    firstTree = trace.tree;
+var firstTree, secondTree, commonTree;
 
-    return builder.trace('app/second');
-  })
-  .then(function(trace) {
-    secondTree = trace.tree;
-    commonTree = builder.intersectTrees(firstTree, secondTree);
+builder.trace('app/first')
+.then(function(trace) {
+  firstTree = trace.tree;
 
-    firstTree = builder.subtractTrees(firstTree, commonTree);
-    secondTree = builder.subtractTrees(secondTree, commonTree);
+  return builder.trace('app/second');
+})
+.then(function(trace) {
+  secondTree = trace.tree;
+  commonTree = builder.intersectTrees(firstTree, secondTree);
 
-    return builder.buildTree(firstTree, 'first-bundle.js');
-  })
-  .then(function() {
-    return builder.buildTree(secondTree, 'second-bundle.js');
-  })
-  .then(function() {
-    return builder.buildTree(commonTree, 'shared-bundle.js');
-  });
+  firstTree = builder.subtractTrees(firstTree, commonTree);
+  secondTree = builder.subtractTrees(secondTree, commonTree);
+
+  return builder.buildTree(firstTree, 'first-bundle.js');
+})
+.then(function() {
+  return builder.buildTree(secondTree, 'second-bundle.js');
+})
+.then(function() {
+  return builder.buildTree(commonTree, 'shared-bundle.js');
+});
 ```
 
 License


### PR DESCRIPTION
Many code blocks in `README.md` are indented by two extra spaces. This removes them so indentation is correct when copying examples.