### PR TITLE
Default to normalize

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -15,7 +15,7 @@ function processOpts(opts_, outFile) {
     config: {},
     lowResSourceMaps: false,
     minify: false,
-    normalize: false,
+    normalize: true,
     outFile: outFile,
     runtime: false,
     sourceMaps: false,
@@ -172,27 +172,45 @@ Builder.prototype.buildExpression = function(expression, cfg) {
   });
 };
 
+function addExtraOutputs(output, tree, opts) {
+  output.modules = Object.keys(tree).filter(function(moduleName) {
+    return tree[moduleName].metadata.build !== false;
+  });
+}
+
 Builder.prototype.buildTree = function(tree, outFile, opts) {
   var loader = this.loader;
+  var self = this;
   opts = processOpts(opts, outFile);
 
   return compileOutputs(loader, tree, opts, false)
   .then(function(outputs) {
     return writeOutputs(opts, outputs, loader.baseURL);
-  });
+  })
+  .then(function(output) {
+    addExtraOutputs.call(self, output, tree, opts, loader);
+    return output;
+  })
 };
 
 Builder.prototype.buildSFX = function(moduleName, outFile, opts) {
   var loader = this.loader;
+  var self = this;
   opts = processOpts(opts, outFile);
   opts.normalize = true;
+  var tree;
 
   return this.trace(moduleName, opts.config)
   .then(function(trace) {
-    return compileOutputs(loader, trace.tree, opts, trace.moduleName);
+    tree = trace.tree;
+    return compileOutputs(loader, tree, opts, trace.moduleName);
   })
   .then(function(outputs) {
     return writeOutputs(opts, outputs, loader.baseURL);
+  })
+  .then(function(output) {
+    addExtraOutputs.call(self, output, tree, opts, loader);
+    return output;
   });
 };
 

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -336,4 +336,17 @@ Builder.extractTree = function(tree, moduleName) {
   });
 };
 
+// given a tree, creates a depCache for it
+Builder.getDepCache = function(tree) {
+  var depCache = {};
+  Object.keys(tree).forEach(function(moduleName) {
+    var load = tree[moduleName];
+    if (load.deps.length)
+      depCache[moduleName] = load.deps.map(function(dep) {
+        return load.depMap[dep];
+      });
+  });
+  return depCache;
+}
+
 module.exports = Builder;


### PR DESCRIPTION
This should actually make production configuration unnecessary in most cases.

This also adds a `modules` array to the output object allowing for easy population of bundles.

There is also a new static method, `Builder.getDepCache(tree)` for easier depCache generation.