### PR TITLE
Add "mangle" to allowed options

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -15,6 +15,7 @@ function processOpts(opts_, outFile) {
     config: {},
     lowResSourceMaps: false,
     minify: false,
+    mangle: true,
     normalize: true,
     runtime: false,
     outFile: outFile,


### PR DESCRIPTION
I've defaulted it to `true` to match the current behaviour in minify.

Looks like this was missed [when whitelisting the options](https://github.com/systemjs/builder/commit/2eee61e8e778bfacc0789a280eb7489a1c963d3b).

---

[`Builder.prototype.buildTree`](https://github.com/systemjs/builder/blob/ed83dff78c4bdb114fa5dd3abf35fd00133bf0b2/lib/builder.js#L175-L183) will `processOpts` before passing them to [`writeOutputs`](https://github.com/systemjs/builder/blob/9859a29a7a5a99273e280c14043573a8df93c947/lib/output.js#L135), removing the `mangle` option if we pass it in. Then [`minify`](https://github.com/systemjs/builder/blob/9859a29a7a5a99273e280c14043573a8df93c947/lib/output.js#L82) will mangle anyway.