### PR TITLE
Rename `returnUsedHelpers` to `metadataUsedHelpers`

### DIFF
--- a/compilers/es6.js
+++ b/compilers/es6.js
@@ -101,7 +101,7 @@ exports.compile = function(load, opts, loader) {
       options.ast = false;
       options.moduleIds = true;
       options.externalHelpers = true;
-      options.returnUsedHelpers = true;
+      options.metadataUsedHelpers = true;
 
       if (normalize)
         options.resolveModuleSource = function(dep) {


### PR DESCRIPTION
This was renamed in babel 5.0.0.

https://github.com/babel/babel/blob/master/CHANGELOG.md