### PR TITLE
Pessimistic support for `includeSourcesContent`

### DIFF
--- a/lib/sourcemaps.js
+++ b/lib/sourcemaps.js
@@ -1,6 +1,7 @@
 var sourceMap = require('source-map');
 var traceur = require('traceur');
 var path = require('path');
+var fs = require('fs');
 
 var wrapSourceMap = function(map) {
   return new sourceMap.SourceMapConsumer(map);
@@ -24,11 +25,7 @@ function getMapObject(map) {
 }
 
 exports.concatenateSourceMaps = function(sourceFilename, mapsWithOffsets, sourceRoot, includeSourcesContent) {
-  if (includeSourcesContent) {
-    console.log('WARNING: `includeSourcesContent` not support yet, ' +
-                'see https://github.com/systemjs/builder/issues/68');
-  }
-
+  var contentsBySource = includeSourcesContent ? {} : null;
   var generated = new sourceMap.SourceMapGenerator({
     file: sourceFilename
   });
@@ -36,6 +33,23 @@ exports.concatenateSourceMaps = function(sourceFilename, mapsWithOffsets, source
   mapsWithOffsets.forEach(function(pair) {
     var offset = pair[0];
     var map = getMapObject(pair[1]);
+
+    if (map.sourcesContent) {
+      for (var i=0; i<map.sources.length; i++) {
+        var source = (map.sourceRoot || '') + map.sources[i];
+        if (!source.match(/\/@traceur/)) {
+          if (includeSourcesContent) {
+            if (!contentsBySource[source]) {
+              contentsBySource[source] = map.sourcesContent[i];
+            } else {
+              if (contentsBySource[source] != map.sourcesContent[i]) {
+                throw "Mismatched sourcesContent for: " + source;
+              }
+            }
+          }
+        }
+      }
+    }
 
     wrapSourceMap(map).eachMapping(function(mapping) {
       if (mapping.source.match(/(\/|^)@traceur/))
@@ -59,6 +73,20 @@ exports.concatenateSourceMaps = function(sourceFilename, mapsWithOffsets, source
 
   // convert from library internals format to canonical
   var normalized = JSON.parse(JSON.stringify(generated));
+
+  if (includeSourcesContent) {
+    normalized.sourcesContent = normalized.sources.map(function(source) {
+    //if (contentsBySource[source])
+      //return contentsBySource[source];
+
+    if (source.substr(0, 6) === 'file:/')
+      return fs.readFileSync(source.replace(/^file:\/+/, '/')).toString();
+
+    // remove this is optimistic return is reliable
+    return contentsBySource[source];
+    });
+  }
+
   // convert paths to relative
   normalized.sources = normalized.sources.map(function(source) {
     if (source.match(/^file:/)) {
@@ -67,5 +95,6 @@ exports.concatenateSourceMaps = function(sourceFilename, mapsWithOffsets, source
       return source;
     }
   });
+
   return JSON.stringify(normalized);
 };

--- a/lib/sourcemaps.js
+++ b/lib/sourcemaps.js
@@ -34,17 +34,15 @@ exports.concatenateSourceMaps = function(sourceFilename, mapsWithOffsets, source
     var offset = pair[0];
     var map = getMapObject(pair[1]);
 
-    if (map.sourcesContent) {
+    if (includeSourcesContent && map.sourcesContent) {
       for (var i=0; i<map.sources.length; i++) {
         var source = (map.sourceRoot || '') + map.sources[i];
         if (!source.match(/\/@traceur/)) {
-          if (includeSourcesContent) {
-            if (!contentsBySource[source]) {
-              contentsBySource[source] = map.sourcesContent[i];
-            } else {
-              if (contentsBySource[source] != map.sourcesContent[i]) {
-                throw "Mismatched sourcesContent for: " + source;
-              }
+          if (!contentsBySource[source]) {
+            contentsBySource[source] = map.sourcesContent[i];
+          } else {
+            if (contentsBySource[source] != map.sourcesContent[i]) {
+              throw "Mismatched sourcesContent for: " + source;
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:traceur": "cd test && node run-build.js && open test-build.html && open test-sfx.html",
     "test:babel": "cd test && node run-build.js babel && open test-build.html && open test-sfx.html",
     "test:unit": "./node_modules/.bin/mocha test/unit-tests.js",
-    "test": "./node_modules/.bin/mocha test/arithmetic.js"
+    "test": "./node_modules/.bin/mocha"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
It's a bit messy - old POC code just rebased. 

Worst part is that it can't rely on existing `sourcesContent` due to (I believe) an issue in Traceur's transitive source maps.