### PR TITLE
exposing original config settings object to users of instances of Builder

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -35,8 +35,11 @@ function Builder(cfg) {
   this.reset();
   if (typeof cfg == 'string')
     this.loadConfigSync(cfg);
-  else if (typeof cfg == 'object')
+  else if (typeof cfg == 'object'){
     this.config(cfg);
+    this.configObject = cfg;
+  }
+    
 }
 
 Builder.prototype.reset = function() {


### PR DESCRIPTION
I couldn't find the original setting anywhere on the builder object. If they are available for access even without this change, please tell me how to access them and close this PR.
If not, please merge.