### PR TITLE
Enable opts as second arg in build, buildTree & buildSFX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 bower_components
 node_modules
 test/output

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea
 bower_components
 node_modules
 test/output

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -30,6 +30,12 @@ function processOpts(opts_, outFile) {
   return opts;
 }
 
+function isPlainObject(obj) {
+  if(Object.getPrototypeOf)
+    return typeof obj === 'object' && Object.prototype === Object.getPrototypeOf(obj);
+  return typeof obj === 'object' && Object === obj.constructor;
+}
+
 function Builder(cfg) {
   this.loader = null;
   this.reset();
@@ -121,6 +127,14 @@ Builder.prototype.config = function(config) {
 
 Builder.prototype.build = function(expression, outFile, opts) {
   var self = this;
+
+  // allow passing opts
+  // as second argument.
+  if(isPlainObject(outFile)){
+    opts = outFile;
+    outFile = undefined;
+  }
+
   opts = opts || {};
 
   if (opts.config)
@@ -141,6 +155,14 @@ function addExtraOutputs(output, tree, opts) {
 Builder.prototype.buildTree = function(tree, outFile, opts) {
   var loader = this.loader;
   var self = this;
+
+  // allow passing opts
+  // as second argument.
+  if(isPlainObject(outFile)){
+    opts = outFile;
+    outFile = undefined;
+  }
+
   opts = processOpts(opts, outFile);
 
   return compileOutputs(loader, tree, opts, false)
@@ -156,6 +178,14 @@ Builder.prototype.buildTree = function(tree, outFile, opts) {
 Builder.prototype.buildSFX = function(expression, outFile, opts) {
   var loader = this.loader;
   var self = this;
+
+  // allow passing opts
+  // as second argument.
+  if(isPlainObject(outFile)){
+    opts = outFile;
+    outFile = undefined;
+  }
+
   opts = opts || {};
   opts.normalize = true;
 


### PR DESCRIPTION
Check if second arg is options instead of outFile. added "isPlainObject" helper. Falls back if Object.getPrototypeOf is not defined.