### PR TITLE
fix(reset): fix for _nodeRequire not being set in plugin (fixes #154)

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -58,8 +58,6 @@ Builder.prototype.reset = function(baseLoader) {
   pluginLoader.trace = true;
   pluginLoader._nodeRequire = baseLoader._nodeRequire;
 
-  var globalSystem = global.System;
-
   // override plugin loader instantiate to first
   // always correct any clobbering of the System global
   // eg by loading Traceur or Traceur Runtime
@@ -73,8 +71,8 @@ Builder.prototype.reset = function(baseLoader) {
   pluginLoader.instantiate = function(load) {
     return Promise.resolve(pluginInstantiate.call(this, load))
     .then(function(instantiateResult) {
-      if (global.System !== globalSystem)
-        global.System = globalSystem;
+      if (global.System !== loader)
+        global.System = loader;
       return instantiateResult;
     });
   };
@@ -84,6 +82,7 @@ Builder.prototype.reset = function(baseLoader) {
   loader.pluginLoader = pluginLoader;
 
   attachCompilers(loader);
+  global.System = loader;
 };
 
 function executeConfigFile(loader, source) {


### PR DESCRIPTION
This fix means that given a loader/pluginLoader pair, whenever pluginLoader.instantiate is called, global.System gets set to loader.

See issue #154.