### PR TITLE
URL hygiene

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -66,7 +66,7 @@ Builder.prototype.reset = function(baseLoader) {
     if (this.defined[load.name])
       delete this.defined[load.name];
     return pluginFetch.call(this, load);
-  }
+  };
   var pluginInstantiate = pluginLoader.instantiate;
   pluginLoader.instantiate = function(load) {
     return Promise.resolve(pluginInstantiate.call(this, load))
@@ -250,7 +250,7 @@ Builder.prototype.traceModule = function(moduleName) {
     if (thisLoad.metadata.bundle) {
       namedRegisterRegEx.lastIndex = 0;
       var curMatch;
-      while (curMatch = namedRegisterRegEx.exec(thisLoad.source))
+      while ((curMatch = namedRegisterRegEx.exec(thisLoad.source)))
         traceTree[curMatch[1].substr(1, curMatch[1].length - 2)] = null;
     }
     else

--- a/lib/output.js
+++ b/lib/output.js
@@ -4,6 +4,8 @@ var fs = require('fs');
 var Promise = require('rsvp').Promise;
 var asp = require('rsvp').denodeify;
 
+var coercePath = require('./utils').coercePath;
+
 function countLines(str) {
   return str.split(/\r\n|\r|\n/).length;
 }
@@ -53,17 +55,17 @@ function processOutputs(outputs) {
   return outputObj;
 }
 
-function createOutput(outputs, outFile, baseURL, opts) {
+function createOutput(outputs, outFile, outputPath, opts) {
   // process output
   var saucy = require('./sourcemaps');
   var sourceMap;
+  var outputURL = 'file:/' + outputPath;
 
   var outputObj = processOutputs(outputs);
 
   if (opts.sourceMaps && outputObj.sourceMapsWithOffsets.length) {
-    var sourceRoot = outFile ? path.dirname(baseURL + outFile) + path.sep : baseURL;
     var mapsWithOffsets = outputObj.sourceMapsWithOffsets;
-    sourceMap = saucy.concatenateSourceMaps(outFile, mapsWithOffsets, sourceRoot, opts.sourceMapContents);
+    sourceMap = saucy.concatenateSourceMaps(outFile, mapsWithOffsets, outputURL, opts.sourceMapContents);
   }
 
   var output = outputObj.sources.join('\n');
@@ -81,7 +83,7 @@ function minify(output, fileName, mangle, globalDefs) {
   ast = ast.transform(uglify.Compressor({
     dead_code: true,
     global_defs: globalDefs,
-    warnings: false 
+    warnings: false
   }));
   ast.figure_out_scope();
   ast.compute_char_frequency();
@@ -139,13 +141,17 @@ function inlineSourceMap (output) {
 }
 
 exports.writeOutputs = function(opts, outputs, baseURL) {
-  // remove 'file:' part
-  var basePath = baseURL.substr(5);
+  var basePath = coercePath(baseURL);
+  var outputPath;
 
-  if (opts.outFile)
+  if (opts.outFile) {
     opts.outFile = path.relative(basePath, path.resolve(opts.outFile));
+    outputPath = path.dirname(path.resolve(basePath, opts.outFile));
+  }
+  else
+    outputPath = basePath;
 
-  var output = createOutput(outputs, opts.outFile, baseURL, opts);
+  var output = createOutput(outputs, opts.outFile, outputPath, opts);
 
   if (opts.minify)
     output = minify(output, opts.outFile, opts.mangle, opts.globalDefs);

--- a/lib/output.js
+++ b/lib/output.js
@@ -59,7 +59,8 @@ function createOutput(outputs, outFile, outputPath, opts) {
   // process output
   var saucy = require('./sourcemaps');
   var sourceMap;
-  var outputURL = 'file:/' + outputPath;
+  var onWindows =  process.platform.match(/^win/);
+  var outputURL = (onWindows ? 'file://' : 'file:/') + outputPath;
 
   var outputObj = processOutputs(outputs);
 

--- a/lib/sourcemaps.js
+++ b/lib/sourcemaps.js
@@ -2,6 +2,8 @@ var sourceMap = require('source-map');
 var traceur = require('traceur');
 var path = require('path');
 var fs = require('fs');
+var filePath = require('./utils').filePath;
+var isFileURL = require('./utils').isFileURL;
 
 var wrapSourceMap = function(map) {
   return new sourceMap.SourceMapConsumer(map);
@@ -71,27 +73,28 @@ exports.concatenateSourceMaps = function(sourceFilename, mapsWithOffsets, source
 
   // convert from library internals format to canonical
   var normalized = JSON.parse(JSON.stringify(generated));
+  var sourcePath;
 
   if (includeSourcesContent) {
     normalized.sourcesContent = normalized.sources.map(function(source) {
     //if (contentsBySource[source])
       //return contentsBySource[source];
 
-    if (source.substr(0, 6) === 'file:/')
-      return fs.readFileSync(source.replace(/^file:\/+/, '/')).toString();
+    sourcePath = filePath(source);
+    if (sourcePath)
+      return fs.readFileSync(sourcePath).toString();
 
     // remove this is optimistic return is reliable
     return contentsBySource[source];
     });
   }
 
-  // convert paths to relative
+  var rootIsPath = isFileURL(sourceRoot);
   normalized.sources = normalized.sources.map(function(source) {
-    if (source.match(/^file:/)) {
+    if (rootIsPath && isFileURL(source))
       return path.relative(sourceRoot, source).replace(/\\/g, '/');
-    } else {
+    else
       return source;
-    }
   });
 
   return JSON.stringify(normalized);

--- a/lib/sourcemaps.js
+++ b/lib/sourcemaps.js
@@ -82,7 +82,7 @@ exports.concatenateSourceMaps = function(sourceFilename, mapsWithOffsets, source
 
     sourcePath = filePath(source);
     if (sourcePath)
-      return fs.readFileSync(sourcePath).toString();
+      try { return fs.readFileSync(sourcePath).toString(); } catch (e) {}
 
     // remove this is optimistic return is reliable
     return contentsBySource[source];

--- a/lib/sourcemaps.js
+++ b/lib/sourcemaps.js
@@ -66,8 +66,6 @@ exports.concatenateSourceMaps = function(sourceFilename, mapsWithOffsets, source
         },
         source: mapping.source
       });
-
-      originalLastLine = mapping.generatedLine;
     });
   });
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,12 +14,10 @@ exports.filePath = filePath;
 
 /* Coerce URLs to paths, assuming they are file URLs */
 function coercePath(url) {
-  // give absolute URLs benefit of the doubt that they are file paths
-  if (path.isAbsolute(url))
-    return url;
-  else if (isFileURL(url))
+  if (isFileURL(url))
     return url.replace(/^file:\/+/, '/');
-  else // assume relative
+  else
+    // assume relative
     return path.resolve(process.cwd(), url);
 }
 exports.coercePath = coercePath;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,25 @@
+var path = require('path');
+
+function isFileURL(url) {
+  return url.substr(0, 5) === 'file:';
+}
+exports.isFileURL = isFileURL;
+
+/* Remove scheme prefix from file URLs, so that they are paths. */
+function filePath(url) {
+  if (isFileURL(url))
+    return url.replace(/^file:\/+/, '/');
+}
+exports.filePath = filePath;
+
+/* Coerce URLs to paths, assuming they are file URLs */
+function coercePath(url) {
+  // give absolute URLs benefit of the doubt that they are file paths
+  if (path.isAbsolute(url))
+    return url;
+  else if (isFileURL(url))
+    return url.replace(/^file:\/+/, '/');
+  else // assume relative
+    return path.resolve(process.cwd(), url);
+}
+exports.coercePath = coercePath;


### PR DESCRIPTION
@guybedford 

This cleans up sticky tape around `file:`, which could go horribly wrong (see #157) and for example rebase absolute URLs against a relative baseURL.

Presenting two approaches: strict (see after first commit) and permissive (see after last commit)

If we decide to go with either of these I'll add some tests.