### PR TITLE
Update README to describe bundleSFX arithmetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ System.meta['resource/to/ignore'] = {
 
 Both `builder.build` and `builder.buildSFX` support bundle arithmetic expressions. This allows for the easy construction of custom bundles.
 
+**NOTE**: SFX Bundles can only use addition and wildcard arithmetic.
+
 There is also a `builder.trace` and `builder.buildTree` for building direct trace tree objects.
 
 #### Example - Arithmetic Expressions


### PR DESCRIPTION
Added documentation to warn users that SFX bundles can only use addition and wildcard arithmetic.