### PR TITLE
extraneous comma in global expression builder

### DIFF
--- a/compilers/global.js
+++ b/compilers/global.js
@@ -90,7 +90,7 @@ GlobalTransformer.prototype.transformScript = function(tree) {
     globalExpression = '{';
     var first = true;
     for (var g in this.globals) {
-      globalExpression += (first ? '' : ',') + nl + '"' + g + '": __require("' + this.globals[g] + '"),';
+      globalExpression += (first ? '' : ',') + nl + '"' + g + '": __require("' + this.globals[g] + '")';
       first = false;
     }
     globalExpression += nl + '}';


### PR DESCRIPTION
specifying more than one global in the meta config breaks the builder.