### PR TITLE
Fix undefined `hasOwnProperty` in IE8

### DIFF
--- a/templates/global-helpers.js
+++ b/templates/global-helpers.js
@@ -1,6 +1,6 @@
 (function(__global) {
   var loader = $__System;
-  var hasOwnProperty = __global.hasOwnProperty;
+  var hasOwnProperty = Object.prototype.hasOwnProperty;
   var indexOf = Array.prototype.indexOf || function(item) {
     for (var i = 0, l = this.length; i < l; i++)
       if (this[i] === item)


### PR DESCRIPTION
IE < 9 does not define `hasOwnProperty` for host objects (see http://stackoverflow.com/a/8159434). This seems to have been fixed in systemjs core already (see https://github.com/systemjs/systemjs/commit/1ee77a#diff-5010b5e8eb34234db769e98607569c59L6).

I wasn't sure if there was some automatic way of updating the helper from `systemjs/systemjs` so I've only touched the line that's broken. Let me know if there's anything else I need to do.