### PR TITLE
Bundle source order in post order traversal order

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -6,7 +6,7 @@ var url = require('url');
 var createHash = require('crypto').createHash;
 var template = require('es6-template-strings');
 var getAlias = require('./utils').getAlias;
-var postOrderTraverseTree = require('./utils').postOrderTraverseTree;
+var getTreeModulesPostOrder = require('./utils').getTreeModulesPostOrder;
 
 var compilerMap = {
   'amd': '../compilers/amd',
@@ -62,7 +62,7 @@ function sfxEncoding(moduleName, encodings) {
 // compiledTree is load tree with "source" and "output" set
 exports.compileOutputs = compileOutputs;
 function compileOutputs(loader, tree, opts, sfxEntryPoints, cache) {
-  var modules = postOrderTraverseTree(tree, sfxEntryPoints);
+  var modules = getTreeModulesPostOrder(tree, sfxEntryPoints);
 
   // if doing an sfx build, obscure module names first
   if (sfxEntryPoints && opts.sfxEncoding !== false) {

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -6,7 +6,7 @@ var url = require('url');
 var createHash = require('crypto').createHash;
 var template = require('es6-template-strings');
 var getAlias = require('./utils').getAlias;
-var getTreeModulesPostOrder = require('./utils').getTreeModulesPostOrder;
+var getTreeModulesPostOrder = require('./trace').getTreeModulesPostOrder;
 
 var compilerMap = {
   'amd': '../compilers/amd',

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -62,7 +62,7 @@ function sfxEncoding(moduleName, encodings) {
 // compiledTree is load tree with "source" and "output" set
 exports.compileOutputs = compileOutputs;
 function compileOutputs(loader, tree, opts, sfxEntryPoints, cache) {
-  var modules = Object.keys(tree);
+  var modules = postOrderTraverseTree(tree, loader, sfxEntryPoints);
 
   // if doing an sfx build, obscure module names first
   if (sfxEntryPoints && opts.sfxEncoding !== false) {

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -6,6 +6,7 @@ var url = require('url');
 var createHash = require('crypto').createHash;
 var template = require('es6-template-strings');
 var getAlias = require('./utils').getAlias;
+var postOrderTraverseTree = require('./utils').postOrderTraverseTree;
 
 var compilerMap = {
   'amd': '../compilers/amd',
@@ -174,7 +175,7 @@ function compileOutputs(loader, tree, opts, sfxEntryPoints, cache) {
       return tree[name].metadata.format == 'amd';
     });
 
-    if (hasAMD) 
+    if (hasAMD)
       outputs.unshift('"bundle";');
   })
 
@@ -294,7 +295,7 @@ function wrapSFXOutputs(loader, tree, outputs, sfxEntryPoints, opts) {
   .then(function() {
     if (opts.sfxGlobalName)
       outputs.unshift('"exports ' + opts.sfxGlobalName + '";');
-    
+
     if (opts.sfxFormat == 'global') {
       for (var g in opts.sfxGlobals)
         outputs.unshift('"globals.' + opts.sfxGlobals[g] + ' ' + g + '";');

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -62,7 +62,7 @@ function sfxEncoding(moduleName, encodings) {
 // compiledTree is load tree with "source" and "output" set
 exports.compileOutputs = compileOutputs;
 function compileOutputs(loader, tree, opts, sfxEntryPoints, cache) {
-  var modules = postOrderTraverseTree(tree, loader, sfxEntryPoints);
+  var modules = postOrderTraverseTree(tree, sfxEntryPoints);
 
   // if doing an sfx build, obscure module names first
   if (sfxEntryPoints && opts.sfxEncoding !== false) {

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -4,6 +4,8 @@ var toFileURL = require('./utils').toFileURL;
 var fromFileURL = require('./utils').fromFileURL;
 var asp = require('rsvp').denodeify;
 var fs = require('fs');
+var Graph = require('algorithms/data_structures/graph');
+var depthFirst = require('algorithms/graph').depthFirstSearch;
 
 module.exports = Trace;
 
@@ -399,4 +401,62 @@ Trace.getLoadDependencies = function(load, traceAllConditionals, conditionalEnv)
   return load.deps.map(function(dep) {
     return load.depMap[dep];
   });
+};
+
+function getGraphEntryPoints(graph, entryPoints) {
+  entryPoints = [].concat(entryPoints || []);
+
+  var modules = Object.keys(graph.adjList);
+  var discarded = {};
+
+  modules.forEach(function (moduleName) {
+    Object.keys(graph.adjList[moduleName]).forEach(function (depName) {
+      discarded[depName] = true;
+    });
+  });
+
+  modules.filter(function (moduleName) {
+    return !discarded[moduleName];
+  }).sort().forEach(function (moduleName) {
+    if (entryPoints.indexOf(moduleName) === -1) {
+      entryPoints.push(moduleName);
+    }
+  });
+
+  return entryPoints;
+}
+
+Trace.getTreeModulesPostOrder = function getTreeModulesPostOrder(tree, entryPoints) {
+  entryPoints = entryPoints || [];
+
+  // Post order traversal sorted module list
+  var postOrder = [];
+  var graph = new Graph(true);
+
+  // Seed graph with all relations
+  Object.keys(tree).forEach(function (moduleName) {
+    var load = tree[moduleName];
+
+    if (!graph.adjList[moduleName]) {
+      graph.addVertex(moduleName);
+    }
+
+    Trace.getLoadDependencies(load).forEach(function (depName) {
+      graph.addEdge(moduleName, depName);
+    });
+  });
+
+  // Post order traversal of graph, one per entryPoint
+  getGraphEntryPoints(graph, entryPoints).forEach(function (entryPoint) {
+    depthFirst(graph, entryPoint, {
+      leaveVertex: function (moduleName) {
+        // Avoid duplicates and modules that have been skipped by tracer
+        if (postOrder.indexOf(moduleName) === -1 && moduleName in tree) {
+          postOrder.push(moduleName);
+        }
+      }
+    });
+  });
+
+  return postOrder;
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -202,7 +202,7 @@ function getGraphEntryPoints(graph, entryPoints) {
   return entryPoints;
 }
 
-exports.postOrderTraverseTree = function postOrderTraverseTree(tree, entryPoints) {
+exports.getTreeModulesPostOrder = function getTreeModulesPostOrder(tree, entryPoints) {
   entryPoints = entryPoints || [];
 
   // Post order traversal sorted module list
@@ -211,14 +211,14 @@ exports.postOrderTraverseTree = function postOrderTraverseTree(tree, entryPoints
 
   // Seed graph with all relations
   Object.keys(tree).forEach(function (moduleName) {
-    var module = tree[moduleName];
+    var load = tree[moduleName];
 
-    if (!graph.adjList[module.name]) {
-      graph.addVertex(module.name);
+    if (!graph.adjList[moduleName]) {
+      graph.addVertex(moduleName);
     }
 
-    module.deps.forEach(function (depName) {
-      graph.addEdge(module.name, module.depMap[depName]);
+    load.deps.forEach(function (depName) {
+      graph.addEdge(moduleName, load.depMap[depName]);
     });
   });
 
@@ -226,17 +226,12 @@ exports.postOrderTraverseTree = function postOrderTraverseTree(tree, entryPoints
   getGraphEntryPoints(graph, entryPoints).forEach(function (entryPoint) {
     depthFirst(graph, entryPoint, {
       leaveVertex: function (moduleName) {
-        // Avoidj duplicates
-        if (postOrder.indexOf(moduleName) === -1) {
+        // Avoid duplicates and modules that have been skipped by tracer
+        if (postOrder.indexOf(moduleName) === -1 && moduleName in tree) {
           postOrder.push(moduleName);
         }
       }
     });
-  });
-
-  // The graph some times includes things the tracer has already discarded. Filter those
-  postOrder = postOrder.filter(function (moduleName) {
-    return moduleName in tree;
   });
 
   return postOrder;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,9 +1,5 @@
 var path = require('path');
 var url = require('url');
-var trace = require('./trace');
-
-var Graph = require('algorithms/data_structures/graph');
-var depthFirst = require('algorithms/graph').depthFirstSearch;
 
 function fromFileURL(url) {
   return url.substr(7 + !!process.platform.match(/^win/)).replace(/\//g, path.sep);
@@ -179,61 +175,3 @@ function getAlias(loader, canonicalName) {
 
   return bestAlias || canonicalName;
 }
-
-function getGraphEntryPoints(graph, entryPoints) {
-  entryPoints = [].concat(entryPoints || []);
-
-  var modules = Object.keys(graph.adjList);
-  var discarded = {};
-
-  modules.forEach(function (moduleName) {
-    Object.keys(graph.adjList[moduleName]).forEach(function (depName) {
-      discarded[depName] = true;
-    });
-  });
-
-  modules.filter(function (moduleName) {
-    return !discarded[moduleName];
-  }).sort().forEach(function (moduleName) {
-    if (entryPoints.indexOf(moduleName) === -1) {
-      entryPoints.push(moduleName);
-    }
-  });
-
-  return entryPoints;
-}
-
-exports.getTreeModulesPostOrder = function getTreeModulesPostOrder(tree, entryPoints) {
-  entryPoints = entryPoints || [];
-
-  // Post order traversal sorted module list
-  var postOrder = [];
-  var graph = new Graph(true);
-
-  // Seed graph with all relations
-  Object.keys(tree).forEach(function (moduleName) {
-    var load = tree[moduleName];
-
-    if (!graph.adjList[moduleName]) {
-      graph.addVertex(moduleName);
-    }
-
-    trace.getLoadDependencies(load).forEach(function (depName) {
-      graph.addEdge(moduleName, depName);
-    });
-  });
-
-  // Post order traversal of graph, one per entryPoint
-  getGraphEntryPoints(graph, entryPoints).forEach(function (entryPoint) {
-    depthFirst(graph, entryPoint, {
-      leaveVertex: function (moduleName) {
-        // Avoid duplicates and modules that have been skipped by tracer
-        if (postOrder.indexOf(moduleName) === -1 && moduleName in tree) {
-          postOrder.push(moduleName);
-        }
-      }
-    });
-  });
-
-  return postOrder;
-};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -230,5 +230,10 @@ exports.postOrderTraverseTree = function postOrderTraverseTree(tree, loader, ent
     });
   });
 
+  // The graph some times includes things the tracer has already discarded. Filter those
+  postOrder = postOrder.filter(function (moduleName) {
+    return moduleName in tree;
+  });
+
   return postOrder;
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -202,7 +202,7 @@ function getGraphEntryPoints(graph, entryPoints) {
   return entryPoints;
 }
 
-exports.postOrderTraverseTree = function postOrderTraverseTree(tree, loader, entryPoints) {
+exports.postOrderTraverseTree = function postOrderTraverseTree(tree, entryPoints) {
   entryPoints = entryPoints || [];
 
   // Post order traversal sorted module list

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -49,14 +49,6 @@ function normalizePath(loader, path, isPlugin) {
 // syntax-free getCanonicalName
 // just reverse-applies paths and defulatJSExtension to determine the canonical
 function getCanonicalNamePlain(loader, normalized, isPlugin) {
-  // add defaultJSExtension for reverse-pathing defaultJSExtension process to work out
-  // due to the fact that plugins remove defaultJSExtensions to begin with
-  var defaultJSExtension = false;
-  if (!isPlugin && loader.defaultJSExtensions && normalized.substr(normalized.length - 3, 3) != '.js') {
-    normalized += '.js';
-    defaultJSExtension = true;
-  }
-
   // now just reverse apply paths rules to get canonical name
   var pathMatch;
 
@@ -133,7 +125,7 @@ function getCanonicalName(loader, normalized, isPlugin) {
     var negate = booleanModule[0] == '~';
     if (negate)
       booleanModule = booleanModule.substr(1);
-    return getCanonicalName(loader, normalized.substr(0, booleanIndex) + '#?' + (negate ? '~' : '') + canonicalizeCondition(loader, booleanModule), isPlugin);
+    return getCanonicalName(loader, normalized.substr(0, booleanIndex)) + '#?' + (negate ? '~' : '') + canonicalizeCondition(loader, booleanModule);
   }
 
   // 2. Plugins

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -213,6 +213,10 @@ exports.postOrderTraverseTree = function postOrderTraverseTree(tree, entryPoints
   Object.keys(tree).forEach(function (moduleName) {
     var module = tree[moduleName];
 
+    if (!graph.adjList[module.name]) {
+      graph.addVertex(module.name);
+    }
+
     module.deps.forEach(function (depName) {
       graph.addEdge(module.name, module.depMap[depName]);
     });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,6 @@
 var path = require('path');
 var url = require('url');
+var trace = require('./trace');
 
 var Graph = require('algorithms/data_structures/graph');
 var depthFirst = require('algorithms/graph').depthFirstSearch;
@@ -217,8 +218,8 @@ exports.getTreeModulesPostOrder = function getTreeModulesPostOrder(tree, entryPo
       graph.addVertex(moduleName);
     }
 
-    load.deps.forEach(function (depName) {
-      graph.addEdge(moduleName, load.depMap[depName]);
+    trace.getLoadDependencies(load).forEach(function (depName) {
+      graph.addEdge(moduleName, depName);
     });
   });
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,9 @@
 var path = require('path');
 var url = require('url');
 
+var Graph = require('algorithms/data_structures/graph');
+var depthFirst = require('algorithms/graph').depthFirstSearch;
+
 function fromFileURL(url) {
   return url.substr(7 + !!process.platform.match(/^win/)).replace(/\//g, path.sep);
 }
@@ -175,3 +178,57 @@ function getAlias(loader, canonicalName) {
 
   return bestAlias || canonicalName;
 }
+
+function getGraphEntryPoints(graph, entryPoints) {
+  entryPoints = [].concat(entryPoints || []);
+
+  var modules = Object.keys(graph.adjList);
+  var discarded = {};
+
+  modules.forEach(function (moduleName) {
+    Object.keys(graph.adjList[moduleName]).forEach(function (depName) {
+      discarded[depName] = true;
+    });
+  });
+
+  modules.filter(function (moduleName) {
+    return !discarded[moduleName];
+  }).sort().forEach(function (moduleName) {
+    if (entryPoints.indexOf(moduleName) === -1) {
+      entryPoints.push(moduleName);
+    }
+  });
+
+  return entryPoints;
+}
+
+exports.postOrderTraverseTree = function postOrderTraverseTree(tree, loader, entryPoints) {
+  entryPoints = entryPoints || [];
+
+  // Post order traversal sorted module list
+  var postOrder = [];
+  var graph = new Graph(true);
+
+  // Seed graph with all relations
+  Object.keys(tree).forEach(function (moduleName) {
+    var module = tree[moduleName];
+
+    module.deps.forEach(function (depName) {
+      graph.addEdge(module.name, module.depMap[depName]);
+    });
+  });
+
+  // Post order traversal of graph, one per entryPoint
+  getGraphEntryPoints(graph, entryPoints).forEach(function (entryPoint) {
+    depthFirst(graph, entryPoint, {
+      leaveVertex: function (moduleName) {
+        // Avoidj duplicates
+        if (postOrder.indexOf(moduleName) === -1) {
+          postOrder.push(moduleName);
+        }
+      }
+    });
+  });
+
+  return postOrder;
+};

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "mocha": "^2.2.5",
     "mocha-phantomjs": "3.5.6",
     "phantomjs": "1.9.18",
-    "typescript": "next"
+    "typescript": "next",
+    "unexpected": "^9.11.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "SystemJS Build Tool",
   "main": "index.js",
   "dependencies": {
+    "algorithms": "^0.9.1",
     "es6-template-strings": "^1.0.0",
     "glob": "^5.0.14",
     "mkdirp": "^0.5.1",

--- a/test/canonicals.js
+++ b/test/canonicals.js
@@ -26,7 +26,7 @@ suite('Canonical Names', function() {
 
   test('Wildcard extensions with a plugin', function() {
     builder.loader.defaultJSExtensions = true;
-    assert.equal(builder.getCanonicalName('cjs'), 'cjs.js');
+    assert.equal(builder.getCanonicalName('cjs'), 'cjs');
     assert.equal(builder.getCanonicalName(baseURL + 'test/dummy/file.jade!' + baseURL + 'test/fixtures/test-tree/jade.js'), 'file.jade!jade');
   });
 });

--- a/test/conditional-canonicals.js
+++ b/test/conditional-canonicals.js
@@ -1,0 +1,33 @@
+var Builder = require('../index');
+
+var builder = new Builder('test/fixtures/conditional-tree');
+builder.loadConfigSync('test/fixtures/conditional-tree.config.js');
+
+var baseURL = builder.loader.baseURL;
+
+builder.config({ defaultJSExtensions: true });
+
+suite('Conditional Canonical Names', function() {
+  test('Package environment canonical', function() {
+    assert.equal(builder.getCanonicalName(baseURL + 'pkg#:env-condition'), 'pkg#:env-condition');
+  });
+  test('Interpolation', function() {
+    assert.equal(builder.getCanonicalName(baseURL + 'interpolated-#{' + baseURL + 'conditions.js|test}.js'), 'interpolated-#{conditions.js|test}.js');
+  });
+  test('Plugin interpolation', function() {
+    assert.equal(builder.getCanonicalName(baseURL + 'pkg/test-#{' + baseURL + 'conditions.js|test}.js!plugin-#{conditions.js|another}.js'), 'pkg/test-#{conditions.js|test}.js!plugin-#{conditions.js|another}.js');
+  });
+  test('Boolean conditional', function() {
+    assert.equal(builder.getCanonicalName(baseURL + 'pkg/test#?~' + baseURL + 'bool|exp'), 'pkg/test#?~bool|exp');
+  });
+  test('Boolean conditional with plugin', function() {
+    builder.config({
+      paths: {
+        a: 'asdf', // only if we add .js this catches
+        condition: 'conditions.js',
+        p: 'plugin'
+      }
+    })
+    assert.equal(builder.getCanonicalName(baseURL + 'asdf.js' + '!' + baseURL + 'plugin.js#?' + baseURL + 'conditions.js'), 'asdf.js!p#?condition');
+  })
+});

--- a/test/test-post-order.js
+++ b/test/test-post-order.js
@@ -1,0 +1,160 @@
+var expect = require('unexpected');
+var getTreeModulesPostOrder = require('../lib/utils').getTreeModulesPostOrder;
+
+suite('Test post order traversal', function() {
+  test('should return single module that has no incoming relation', function() {
+    var tree = {
+      'a': {
+        deps: [],
+        depMap: {}
+      }
+    };
+
+    return expect(getTreeModulesPostOrder(tree), 'to satisfy', ['a']);
+  });
+
+  test('should return modules that has no incoming relations', function() {
+    var tree = {
+      'a': {
+        deps: [],
+        depMap: {}
+      },
+      'b': {
+        deps: [],
+        depMap: {}
+      }
+    };
+
+    return expect(getTreeModulesPostOrder(tree), 'to satisfy', ['a', 'b']);
+  });
+
+  test('should resolve module names based on depMap', function() {
+    var tree = {
+      'a': {
+        deps: ['foo'],
+        depMap: {
+          'foo': 'b'
+        }
+      },
+      'b': {
+        deps: [],
+        depMap: {}
+      }
+    };
+
+    return expect(getTreeModulesPostOrder(tree), 'to satisfy', ['b', 'a']);
+  });
+
+  test('should order modules with dependencies first', function() {
+    var tree = {
+      'a': {
+        deps: ['b', 'd'],
+        depMap: {
+          'b': 'b',
+          'd': 'd'
+        }
+      },
+      'b': {
+        deps: ['c'],
+        depMap: {
+          'c': 'c'
+        }
+      },
+      'c': {
+        deps: [],
+        depMap: {}
+      },
+      'd': {
+        deps: [],
+        depMap: {}
+      }
+    };
+
+    return expect(getTreeModulesPostOrder(tree), 'to satisfy', ['c', 'b', 'd', 'a']);
+  });
+
+  test('should order graph entries alphabetically', function() {
+    var tree = {
+      'a': {
+        deps: ['b'],
+        depMap: {
+          'b': 'b'
+        }
+      },
+      'b': {
+        deps: ['c'],
+        depMap: {
+          'c': 'c'
+        }
+      },
+      'c': {
+        deps: [],
+        depMap: {}
+      },
+      'd': {
+        deps: [],
+        depMap: {}
+      }
+    };
+
+    return expect(getTreeModulesPostOrder(tree), 'to satisfy', ['c', 'b', 'a', 'd']);
+  });
+
+  test('should override alphabetical graph entry order with entryPoints array', function() {
+    var tree = {
+      'a': {
+        deps: ['b'],
+        depMap: {
+          'b': 'b'
+        }
+      },
+      'b': {
+        deps: ['c'],
+        depMap: {
+          'c': 'c'
+        }
+      },
+      'c': {
+        deps: [],
+        depMap: {}
+      },
+      'd': {
+        deps: [],
+        depMap: {}
+      }
+    };
+
+    return expect(getTreeModulesPostOrder(tree, ['d', 'a']), 'to satisfy', ['d', 'c', 'b', 'a']);
+  });
+
+  test('should include entry points not present in given entryPoints order, in alphabetical order', function() {
+    var tree = {
+      'a': {
+        deps: ['b'],
+        depMap: {
+          'b': 'b'
+        }
+      },
+      'b': {
+        deps: ['c'],
+        depMap: {
+          'c': 'c'
+        }
+      },
+      'c': {
+        deps: [],
+        depMap: {}
+      },
+      'd': {
+        deps: [],
+        depMap: {}
+      },
+      'e': {
+        deps: [],
+        depMap: {}
+      }
+    };
+
+    return expect(getTreeModulesPostOrder(tree, ['d']), 'to satisfy', ['d', 'c', 'b', 'a', 'e']);
+  });
+});

--- a/test/test-post-order.js
+++ b/test/test-post-order.js
@@ -1,5 +1,5 @@
 var expect = require('unexpected');
-var getTreeModulesPostOrder = require('../lib/utils').getTreeModulesPostOrder;
+var getTreeModulesPostOrder = require('../lib/trace').getTreeModulesPostOrder;
 
 suite('Test post order traversal', function() {
   test('should return single module that has no incoming relation', function() {


### PR DESCRIPTION
This PR fixes indeterministic source order in bundles, which means that bundle filename hashing will be consistent for unchanged sources.

Further more it order the sources in a way so dependencies for modules always comes before the module that requires it. In cases where parsing the bundle itself causes side effects by one module, which a module later in the load order depends on, bundling does not break these implicit side effect dependencies. This improves robustness for compatibility with non-module loader code.

Tests are not passing yet. I have one or two quirks that I still need to resolve