### PR TITLE
Option to transpile cjs to es5 with traceur

### DIFF
--- a/compilers/cjs.js
+++ b/compilers/cjs.js
@@ -131,6 +131,10 @@ exports.compile = function(load, opts, loader) {
   transformer = new CJSRegisterTransformer(!opts.anonymous && load.name, deps, load.path, opts.minify, globals, opts.systemGlobal);
   tree = transformer.transformAny(tree);
 
+  if (opts['cjs-to-es5']) {
+    tree = compiler.transform(tree, load.address);
+  }
+
   var output = compiler.write(tree, load.path);
 
   return Promise.resolve({

--- a/compilers/esm.js
+++ b/compilers/esm.js
@@ -71,7 +71,7 @@ exports.compile = function(load, opts, loader) {
 
       var compiler = new transpiler.Compiler(options);
 
-      var tree = compiler.parse(source, load.address);
+      var tree = compiler.parse(source, load.path);
 
       var transformer = new TraceurImportNormalizeTransformer(function(dep) {
         return normalize ? load.depMap[dep] : dep;
@@ -81,7 +81,7 @@ exports.compile = function(load, opts, loader) {
 
       tree = compiler.transform(tree, load.name);
 
-      var outputSource = compiler.write(tree, load.address);
+      var outputSource = compiler.write(tree, load.path);
 
       if (outputSource.match(/\$traceurRuntime/))
         load.metadata.usesTraceurRuntimeGlobal = true;
@@ -100,7 +100,7 @@ exports.compile = function(load, opts, loader) {
       var transpileOptions = { 
         compilerOptions: options, 
         renamedDependencies: load.depMap, 
-        fileName: load.address, 
+        fileName: load.path, 
         moduleName: !opts.anonymous && load.name 
       };
       
@@ -125,9 +125,9 @@ exports.compile = function(load, opts, loader) {
         options.sourceMap = true;
       if (load.metadata.sourceMap)
         options.inputSourceMap = load.metadata.sourceMap;
-      options.filename = load.address;
+      options.filename = load.path;
       options.filenameRelative = load.name;
-      options.sourceFileName = load.address;
+      options.sourceFileName = load.path;
       options.keepModuleIdExtensions = true;
       options.code = true;
       options.ast = false;
@@ -165,8 +165,8 @@ exports.compile = function(load, opts, loader) {
     }
   })
   .then(function(output) {
-    if (opts.sfx)
-      output.source = output.source.replace(/System\.register\(/, '$__System.register(');
+    if (opts.systemGlobal != 'System')
+      output.source = output.source.replace(/System\.register\(/, opts.systemGlobal + '.register(');
     return output;
   });
 };

--- a/compilers/register.js
+++ b/compilers/register.js
@@ -62,7 +62,7 @@ exports.compile = function(load, opts, loader) {
     options.inputSourceMap = load.metadata.sourceMap;
 
   var compiler = new traceur.Compiler(options);
-  var tree = compiler.parse(load.source, load.address);
+  var tree = compiler.parse(load.source, load.path);
 
   var transformer = new RegisterTransformer(!opts.anonymous && load.name, function(dep) { return opts.normalize ? load.depMap[dep] : dep; });
   tree = transformer.transformAny(tree);
@@ -72,12 +72,12 @@ exports.compile = function(load, opts, loader) {
   // so we need to reconstruct files with load.metadata.execute etc
   // if this comes up, we can tackle it or work around it
   if (!transformer.hasAnonRegister)
-    throw new TypeError('Source ' + load.address + ' is already a bundle file, so can\'t be built as a module.');
+    throw new TypeError('Source ' + load.path + ' is already a bundle file, so can\'t be built as a module.');
 
-  var output = compiler.write(tree, load.address);
+  var output = compiler.write(tree, load.path);
 
-  if (opts.sfx)
-    output = output.replace(/System\.register\(/, '$__System.register(');
+  if (opts.systemGlobal != 'System')
+    output = output.replace(/System\.register\(/, opts.systemGlobal + '.register(');
 
   return Promise.resolve({
     source: output,

--- a/lib/arithmetic.js
+++ b/lib/arithmetic.js
@@ -139,17 +139,6 @@ exports.traceExpression = function(builder, expression, traceOpts) {
         });
       });
     }, Promise.resolve({}));
-  })
-  .then(function(tree) {
-    // get canonicalized entry points
-    return { 
-      tree: tree, 
-      entryPoints: expandedOperations.filter(function(op) {
-        return op.operator == '+' && tree[op.moduleName];
-      }).map(function(op) {
-        return op.moduleName;
-      })
-    };
   });
 };
 

--- a/lib/arithmetic.js
+++ b/lib/arithmetic.js
@@ -56,6 +56,7 @@ function getTreeModuleOperation(builder, symbol) {
 
       return Promise.resolve(builder.loader.normalize(module))
       .then(function(normalized) {
+        normalized = builder.getCanonicalName(normalized);
         return builder.tracer.getLoadRecord(normalized).then(function(load) {
           addedTree[module] = load;
           return addedTree;

--- a/lib/arithmetic.js
+++ b/lib/arithmetic.js
@@ -145,7 +145,7 @@ exports.traceExpression = function(builder, expression, traceOpts) {
     return { 
       tree: tree, 
       entryPoints: expandedOperations.filter(function(op) {
-        return op.operator == '+';
+        return op.operator == '+' && tree[op.moduleName];
       }).map(function(op) {
         return op.moduleName;
       })

--- a/lib/arithmetic.js
+++ b/lib/arithmetic.js
@@ -17,9 +17,9 @@ function parseExpression(expressionString) {
     var moduleName = args[i + 1];
 
     if (operator !== '+' && operator !== '-' && operator !== '&')
-      throw 'Expected operator before ' + operator;
+      throw new TypeError('Expected operator before ' + operator);
     if (!moduleName)
-      throw 'A module name is needed after ' + operator;
+      throw new TypeError('A module name is needed after ' + operator);
 
     // detect [moduleName] syntax for individual modules not trees
     var singleModule = moduleName.substr(0, 1) == '[' && moduleName.substr(moduleName.length - 1, 1) == ']';
@@ -36,57 +36,56 @@ function parseExpression(expressionString) {
   return operations;
 }
 
-function getTreeOperation(builder, symbol) {
+function getTreeOperation(symbol) {
   if (symbol == '+')
-    return builder.addTrees;
+    return addTrees;
   else if (symbol == '-')
-    return builder.subtractTrees;
+    return subtractTrees;
   else if (symbol == '&')
-    return builder.intersectTrees;
+    return intersectTrees;
   else
-    throw 'Unknown operator ' + symbol;
+    throw new TypeError('Unknown operator ' + symbol);
 }
 
 function getTreeModuleOperation(builder, symbol) {
   if (symbol == '+')
-    return function(tree, module) {
+    return function(tree, canonical) {
       var addedTree = {};
       for (var p in tree)
         addedTree[p] = tree[p];
 
-      return Promise.resolve(builder.loader.normalize(module))
-      .then(function(normalized) {
-        normalized = builder.getCanonicalName(normalized);
-        return builder.tracer.getLoadRecord(normalized).then(function(load) {
-          addedTree[module] = load;
-          return addedTree;
-        });
+      return builder.tracer.getLoadRecord(canonical).then(function(load) {
+        addedTree[module] = load;
+        return addedTree;
       });
     };
   else if (symbol == '-')
-    return function(tree, module) {
-      return Promise.resolve(builder.loader.normalize(module))
-      .then(function(normalized) {
-        normalized = builder.getCanonicalName(normalized);
-        var subtractedTree = {};
-        for (var p in tree) {
-          if (p != normalized)
-            subtractedTree[p] = tree[p];
-        }
-        return subtractedTree;
-      });
+    return function(tree, canonical) {
+      var subtractedTree = {};
+      for (var p in tree) {
+        if (p != canonical)
+          subtractedTree[p] = tree[p];
+      }
+      return subtractedTree;
     };
   else if (symbol == '&')
-    throw 'Single modules cannot be intersected.';
+    throw new TypeError('Single modules cannot be intersected.');
   else
-    throw 'Unknown operator ' + symbol;
+    throw new TypeError('Unknown operator ' + symbol);
 }
 
-function expandGlob(builder, operation) {
-  if (operation.moduleName.indexOf('*') == -1)
-    return [operation];
-
+function expandGlobAndCanonicalize(builder, operation) {
   var loader = builder.loader;
+
+  // no glob -> just canonicalize
+  if (operation.moduleName.indexOf('*') == -1)
+    return loader.normalize(operation.moduleName)
+    .then(function(normalized) {
+      operation.moduleName = builder.getCanonicalName(normalized);
+      return [operation];
+    });
+
+  // globbing
   var metadata = {};
   return loader.normalize(operation.moduleName)
   .then(function(normalized) {
@@ -110,7 +109,7 @@ function expandGlob(builder, operation) {
   });
 }
 
-exports.traceExpression = function(builder, expression, sfx) {
+exports.traceExpression = function(builder, expression, traceOpts) {
   var operations = parseExpression(expression);
   var expandedOperations = [];
 
@@ -118,7 +117,7 @@ exports.traceExpression = function(builder, expression, sfx) {
   var expandPromise = Promise.resolve();
   operations.forEach(function(operation) {
     expandPromise = expandPromise.then(function() {
-      return Promise.resolve(expandGlob(builder, operation))
+      return Promise.resolve(expandGlobAndCanonicalize(builder, operation))
       .then(function(expanded) {
         expandedOperations = expandedOperations.concat(expanded);
       });
@@ -132,31 +131,79 @@ exports.traceExpression = function(builder, expression, sfx) {
         // tree . module
         if (op.singleModule)
           return getTreeModuleOperation(builder, op.operator)(curTree, op.moduleName);
-
+        
         // tree . tree
-        return builder.traceModule(op.moduleName)
+        return builder.tracer.traceModule(op.moduleName, traceOpts.traceAllConditionals, traceOpts.conditions, traceOpts.traceConditionsOnly)
         .then(function(nextTrace) {
-          return getTreeOperation(builder, op.operator)(curTree, nextTrace.tree);
+          return getTreeOperation(op.operator)(curTree, nextTrace.tree);
         });
       });
     }, Promise.resolve({}));
   })
   .then(function(tree) {
-    if (!sfx)
-      return tree;
-
-    // normalize entry points
-    return Promise.all(expandedOperations.map(function(op) {
-      return builder.loader.normalize(op.moduleName);
-    }))
-    .then(function(normalizedEntryPoints) {
-      normalizedEntryPoints = normalizedEntryPoints.map(function(entryPoint) {
-        return builder.getCanonicalName(entryPoint);
-      });
-      return { 
-        tree: tree, 
-        entryPoints: normalizedEntryPoints
-      };
-    });
+    // get canonicalized entry points
+    return { 
+      tree: tree, 
+      entryPoints: expandedOperations.filter(function(op) {
+        return op.operator == '+';
+      }).map(function(op) {
+        return op.moduleName;
+      })
+    };
   });
+};
+
+
+// returns a new tree containing tree1 n tree2
+exports.intersectTrees = intersectTrees;
+function intersectTrees(tree1, tree2) {
+  var name;
+  var intersectTree = {};
+
+  var tree1Names = [];
+  for (name in tree1)
+    tree1Names.push(name);
+
+  for (name in tree2) {
+    if (tree1Names.indexOf(name) == -1)
+      continue;
+    // intersect deps layer (load: false) and actual bundle includes separately
+    if (!tree2[name] && tree1[name] || tree2[name] && !tree1[name])
+      continue;
+
+    intersectTree[name] = tree1[name] || tree2[name] || false;
+  }
+
+  return intersectTree;
+};
+
+// returns a new tree containing tree1 + tree2
+exports.addTrees = addTrees;
+function addTrees(tree1, tree2) {
+  var name;
+  var unionTree = {};
+
+  for (name in tree2)
+    unionTree[name] = tree2[name] || tree1[name] || false;
+
+  for (name in tree1)
+    unionTree[name] = tree1[name] || tree2[name] || false;
+
+  return unionTree;
+}
+
+// returns a new tree containing tree1 - tree2
+exports.subtractTrees = subtractTrees;
+function subtractTrees(tree1, tree2) {
+  var name;
+  var subtractTree = {};
+
+  for (name in tree1)
+    subtractTree[name] = tree1[name];
+
+  for (name in tree2)
+    if (tree2[name])
+      delete subtractTree[name];
+
+  return subtractTree;
 };

--- a/lib/arithmetic.js
+++ b/lib/arithmetic.js
@@ -168,10 +168,10 @@ function intersectTrees(tree1, tree2) {
     if (tree1Names.indexOf(name) == -1)
       continue;
     // intersect deps layer (load: false) and actual bundle includes separately
-    if (!tree2[name] && tree1[name] || tree2[name] && !tree1[name])
+    if (tree1[name] === false && tree2[name] === false)
       continue;
 
-    intersectTree[name] = tree1[name] || tree2[name] || false;
+    intersectTree[name] = tree1[name] || tree2[name];
   }
 
   return intersectTree;
@@ -184,10 +184,11 @@ function addTrees(tree1, tree2) {
   var unionTree = {};
 
   for (name in tree2)
-    unionTree[name] = tree2[name] || tree1[name] || false;
+    unionTree[name] = tree2[name];
 
   for (name in tree1)
-    unionTree[name] = tree1[name] || tree2[name] || false;
+    if (!(name in unionTree))
+      unionTree[name] = tree1[name];
 
   return unionTree;
 }
@@ -202,7 +203,7 @@ function subtractTrees(tree1, tree2) {
     subtractTree[name] = tree1[name];
 
   for (name in tree2)
-    if (tree2[name])
+    if (tree2[name] !== false || tree1[name] === false)
       delete subtractTree[name];
 
   return subtractTree;

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -221,7 +221,7 @@ Builder.prototype.build = function(expression, outFile, opts) {
 
 function addExtraOutputs(output, tree, opts) {
   output.modules = Object.keys(tree).filter(function(moduleName) {
-    return tree[moduleName].metadata.build !== false;
+    return tree[moduleName];
   });
 }
 
@@ -308,14 +308,14 @@ Builder.prototype.traceModule = function(moduleName) {
   })
   .then(function(loads) {
     // if it is a bundle, we just use a regex to extract the list of loads
-    // as null records for subtraction arithmetic use only
+    // as "true" records for subtraction arithmetic use only
     var thisLoad = loads[moduleName];
 
     if (thisLoad && thisLoad.metadata.bundle) {
       namedRegisterRegEx.lastIndex = 0;
       var curMatch;
       while ((curMatch = namedRegisterRegEx.exec(thisLoad.source)))
-        loads[curMatch[3].substr(1, curMatch[3].length - 2)] = null;
+        loads[curMatch[3].substr(1, curMatch[3].length - 2)] = true;
     }
 
     return {
@@ -371,7 +371,8 @@ Builder.prototype.subtractTrees = function(tree1, tree2) {
     subtractTree[name] = tree1[name];
 
   for (name in tree2)
-    delete subtractTree[name];
+    if (tree2[name])
+      delete subtractTree[name];
 
   return subtractTree;
 };

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -5,10 +5,10 @@ var asp = require('rsvp').denodeify;
 var fs = require('fs');
 var path = require('path');
 
-var toFileURL = require('./utils').toFileURL;
+var extend = require('./utils').extend;
 
 var attachCompilers = require('./compile').attachCompilers;
-var compileOutputs = require('./compile').compileOutputs;
+var compileTree = require('./compile').compileTree;
 var compileLoad = require('./compile').compileLoad;
 
 var writeOutputs = require('./output').writeOutputs;
@@ -23,33 +23,6 @@ require('rsvp').on('error', function(reason) {
   throw new Error('Unhandled promise rejection.\n' + reason && reason.stack || reason || '' + '\n');
 });
 
-function processOpts(opts_, outFile) {
-  var opts = {
-    config: {},
-    outFile: outFile,
-    normalize: true,
-    anonymous: false,
-
-    runtime: false,
-    minify: false,
-    mangle: true,
-
-    sfx: false,
-    sfxFormat: 'global',
-    sfxEncoding: true,
-    sfxGlobals: {},
-    sfxGlobalName: null,
-
-    sourceMaps: false,
-    sourceMapContents: opts_ && opts_.sourceMaps == 'inline',
-    lowResSourceMaps: false
-  };
-  for (var key in opts_)
-    opts[key] = opts_[key];
-  return opts;
-}
-
-
 function Builder(baseURL, cfg) {
   if (typeof baseURL == 'object') {
     cfg = baseURL;
@@ -57,23 +30,19 @@ function Builder(baseURL, cfg) {
   }
 
   this.loader = null;
-  this.reset();
 
-  this.loader.getCanonicalName = this.getCanonicalName.bind(this);
+  this.reset();
 
   if (baseURL)
     this.config({ baseURL: baseURL });
 
+  // config passed to constructor will
+  // be saved for future .reset() calls
   if (typeof cfg == 'object')
-    this.config(cfg);
+    this.config(cfg, true, !!baseURL);
   else if (typeof cfg == 'string')
-    this.loadConfigSync(cfg);
+    this.loadConfigSync(cfg, true, !!baseURL);
 }
-
-// reverse mapping from globbed address
-Builder.prototype.getCanonicalName = function(normalized) {
-  return getCanonicalName(this.loader, normalized);
-};
 
 Builder.prototype.reset = function(baseLoader) {
   baseLoader = baseLoader || this.loader || System;
@@ -107,6 +76,9 @@ Builder.prototype.reset = function(baseLoader) {
   };
 
   loader.builder = true;
+  
+  this.getCanonicalName = getCanonicalName.bind(null, this.loader);
+  this.loader.getCanonicalName = this.getCanonicalName;
 
   attachCompilers(loader);
   global.System = loader;
@@ -125,13 +97,16 @@ Builder.prototype.reset = function(baseLoader) {
     });
   };
 
+  if (this.resetConfig)
+    loader.config(this.resetConfig);
+
   // clear the cache
   this.setCache({});
 };
 
 Builder.prototype.setCache = function(cacheObj) {
   this.cache = {
-    compile: cacheObj.compile || {},
+    compile: cacheObj.compile || { encodings: {}, loads: {} },
     trace: cacheObj.trace || {}
   };
   this.tracer = new Trace(this.loader, this.cache.trace);
@@ -141,12 +116,12 @@ Builder.prototype.getCache = function() {
   return this.cache;
 };
 
-function executeConfigFile(source) {
-  var self = this;
+function executeConfigFile(source, saveForReset, ignoreBaseURL) {
+  var builder = this;
   var curSystem = global.System;
   var configSystem = global.System = {
     config: function(cfg) {
-      self.config(cfg);
+      builder.config(cfg, ignoreBaseURL);
     }
   };
   // jshint evil:true
@@ -154,26 +129,115 @@ function executeConfigFile(source) {
   global.System = curSystem;
 }
 
-Builder.prototype.loadConfig = function(configFile) {
+Builder.prototype.loadConfig = function(configFile, saveForReset, ignoreBaseURL) {
   return asp(fs.readFile)(configFile)
-  .then(executeConfigFile.bind(this));
+  .then(executeConfigFile.bind(this, saveForReset, ignoreBaseURL));
 };
 
-Builder.prototype.loadConfigSync = function(configFile) {
+Builder.prototype.loadConfigSync = function(configFile, saveForReset, ignoreBaseURL) {
   var source = fs.readFileSync(configFile);
-  executeConfigFile.call(this, source);
+  executeConfigFile.call(this, source, saveForReset, ignoreBaseURL);
 };
 
-Builder.prototype.config = function(config) {
-  var loader = this.loader;
-
+Builder.prototype.config = function(config, saveForReset, ignoreBaseURL) {
   var cfg = {};
   for (var p in config) {
-    if (p != 'bundles')
-      cfg[p] = config[p];
+    if (ignoreBaseURL && p == 'baseURL' || p == 'bundles')
+      continue;
+    cfg[p] = config[p];
   }
-  loader.config(cfg);
+  if (saveForReset)
+    this.resetConfig = cfg;
+  this.loader.config(cfg);
 };
+
+/*
+ * Builder Operations
+ */
+
+
+function processTraceOpts(options, defaults) {
+  var opts = {    
+    // conditional tracing options
+    browser: undefined,
+    node: undefined,
+    traceAllConditionals: true,
+    conditions: {},
+    traceConditionsOnly: false
+  };
+
+  extend(opts, defaults)
+  extend(opts, options);
+
+  // conditional tracing defaults
+  if (typeof opts.browser == 'boolean' || typeof opts.node == 'boolean') {
+    var sysEnv = conditions['@system-env'] = conditions['@system-env'] || {};
+
+    if (typeof opts.browser == 'boolean' && typeof opts.node != 'boolean')
+      opts.node = false;
+    if (typeof opts.node == 'boolean' && typeof opts.browser != 'boolean')
+      opts.browser = false;
+    
+    sysEnv['browser'] = opts.browser;
+    sysEnv['~browser'] = !opts.browser;
+    sysEnv['node'] = opts.node;
+    sysEnv['~node'] = !opts.node;
+  }
+
+  return opts;
+}
+
+Builder.prototype.trace = function(expression, opts) {
+  if (opts && opts.config)
+    this.config(opts.config);
+
+  return traceExpression(this, expression, processTraceOpts(opts))
+  .then(function(trace) {
+    return trace.tree;
+  });
+};
+
+function processCompileOpts(options, defaults) {
+  var opts = {
+    normalize: true,
+    anonymous: false,
+
+    systemGlobal: 'System',
+    static: false,
+    encodeNames: undefined,
+
+    sourceMaps: false,
+    lowResSourceMaps: false,
+
+    // static build options
+    // it may make sense to split this out into build options
+    // at a later point as static build and bundle compile diverge further
+    runtime: false,
+    format: 'global',
+    globalDeps: {},
+    globalName: null,
+
+    // this shouldn't strictly be a compile option,
+    // but the cjs compiler needs it to do NODE_ENV optimization
+    minify: false
+  };
+
+  extend(opts, defaults);
+  extend(opts, options);
+
+  if (opts.static) {
+    if (opts.encodeNames !== false)
+      opts.encodeNames = true;
+    // include runtime by default if needed
+    if (opts.runtime !== false)
+      opts.runtime = true;
+
+    // static builds have a System closure with a dummy name
+    opts.systemGlobal = '$__System';
+  }
+
+  return opts;
+}
 
 Builder.prototype.compile = function(moduleName, outFile, opts) {
   if (outFile && typeof outFile == 'object') {
@@ -181,10 +245,9 @@ Builder.prototype.compile = function(moduleName, outFile, opts) {
     outFile = undefined;
   }
 
-  opts = processOpts(opts, outFile);
+  if (opts && opts.config)
+    this.config(opts.config);
 
-  opts.anonymous = true;
-  
   var self = this;
 
   return Promise.resolve(self.loader.normalize(moduleName))
@@ -192,202 +255,115 @@ Builder.prototype.compile = function(moduleName, outFile, opts) {
     return self.tracer.getLoadRecord(getCanonicalName(self.loader, moduleName));
   })
   .then(function(load) {
-    return compileLoad(self.loader, load, opts);
+    return compileLoad(self.loader, load, processCompileOpts(opts, { normalize: false, anonymous: true }), self.cache.compile);
   })
   .then(function(output) {
-    return writeOutputs(opts, [output], self.loader.baseURL);
+    return writeOutputs([output], self.loader.baseURL, processOutputOpts(opts, { outFile: outFile }));
   });
 };
 
-Builder.prototype.build = function(expression, outFile, opts) {
-  var self = this;
+function processOutputOpts(options, defaults) {
+  var opts = {
+    outFile: undefined,
+    
+    minify: false,
+    mangle: true,
+    globalDefs: undefined,
 
-  // Allow passing opts as second argument.
-  if (outFile && typeof outFile === 'object') {
-    opts = outFile;
-    outFile = undefined;
-  }
+    sourceMaps: false,
+    sourceMapContents: undefined
+  };
 
-  opts = opts || {};
+  extend(opts, defaults);
+  extend(opts, options);
 
-  if (opts.config)
-    this.config(opts.config);
+  // source maps 'inline' handling
+  if (opts.sourceMapContents === undefined)
+    opts.sourceMapContents = opts.sourceMaps == 'inline';
 
-  return this.trace(expression)
-  .then(function(tree) {
-    return self.buildTree(tree, outFile, opts);
-  });
-};
-
-function addExtraOutputs(output, tree, opts) {
-  output.modules = Object.keys(tree).filter(function(moduleName) {
-    return tree[moduleName];
-  });
+  return opts;
 }
 
-Builder.prototype.buildTree = function(tree, outFile, opts) {
-  var loader = this.loader;
-  var self = this;
-
-  // Allow passing opts as second argument.
+// bundle
+Builder.prototype.bundle = function(expressionOrTree, outFile, opts) {
   if (outFile && typeof outFile === 'object') {
     opts = outFile;
     outFile = undefined;
   }
 
-  opts = processOpts(opts, outFile);
-
-  var cache = this.cache.compile;
-
-  return compileOutputs(loader, tree, opts, false, cache)
-  .then(function(outputs) {
-    return writeOutputs(opts, outputs, loader.baseURL);
-  })
-  .then(function(output) {
-    addExtraOutputs.call(self, output, tree, opts, loader);
-    return output;
-  });
-};
-
-Builder.prototype.buildSFX = function(expression, outFile, opts) {
-  var loader = this.loader;
   var self = this;
 
-  // Allow passing opts as second argument.
-  if (outFile && typeof outFile === 'object') {
-    opts = outFile;
-    outFile = undefined;
-  }
-
-  opts = opts || {};
-  opts.normalize = true;
-  opts.sfx = true;
-
-  // include runtime by default if needed
-  if (opts.runtime !== false)
-    opts.runtime = true;
-
-  opts = processOpts(opts, outFile);
-  var tree;
-
-  if (opts.config)
+  if (opts && opts.config)
     this.config(opts.config);
 
-  var cache = this.cache.compile;
+  var outputOpts = processOutputOpts(opts, { outFile: outFile });
 
-  return traceExpression(this, expression, true)
+  return Promise.resolve()
+  .then(function() {
+    if (typeof expressionOrTree != 'string')
+      return { tree: expressionOrTree };
+
+    return traceExpression(self, expressionOrTree, processTraceOpts(opts));
+  })
   .then(function(trace) {
-    tree = trace.tree;
-    return compileOutputs(loader, tree, opts, trace.entryPoints, cache);
-  })
-  .then(function(outputs) {
-    return writeOutputs(opts, outputs, loader.baseURL);
-  })
-  .then(function(output) {
-    addExtraOutputs.call(self, output, tree, opts, loader);
-    return output;
+    return compileTree(self.loader, trace.tree, trace.entryPoints || [], processCompileOpts(opts), outputOpts, self.cache.compile)
+    .then(function(outputs) {
+      return writeOutputs(outputs, self.loader.baseURL, outputOpts);
+    })
+    .then(function(output) {
+      output.modules = Object.keys(trace.tree).filter(function(moduleName) {
+        return trace.tree[moduleName];
+      });
+      return output;
+    });
   });
 };
 
-Builder.prototype.trace = function(expression) {
-  return traceExpression(this, expression);
-};
-
-var namedRegisterRegEx = /(System\.register(Dynamic)?|define)\(('[^']+'|"[^"]+")/g;
-
-Builder.prototype.traceModule = function(moduleName) {
-
-  var loader = this.loader;
-
-  var self = this;
-  
-  return Promise.resolve(loader.normalize(moduleName))
-  .then(function(_moduleName) {
-    moduleName = getCanonicalName(loader, _moduleName);
-    return self.tracer.getAllLoadRecords(moduleName, true, {});
-  })
-  .then(function(loads) {
-    // if it is a bundle, we just use a regex to extract the list of loads
-    // as "true" records for subtraction arithmetic use only
-    var thisLoad = loads[moduleName];
-
-    if (thisLoad && thisLoad.metadata.bundle) {
-      namedRegisterRegEx.lastIndex = 0;
-      var curMatch;
-      while ((curMatch = namedRegisterRegEx.exec(thisLoad.source)))
-        loads[curMatch[3].substr(1, curMatch[3].length - 2)] = true;
-    }
-
-    return {
-      moduleName: moduleName,
-      tree: loads
-    };
-  })
-  .catch(function(e) {
-    loader.global.System = System;
-    throw e;
-  });
-};
-
-// returns a new tree containing tree1 n tree2
-Builder.prototype.intersectTrees = function(tree1, tree2) {
-  var name;
-  var intersectTree = {};
-
-  var tree1Names = [];
-  for (name in tree1)
-    tree1Names.push(name);
-
-  for (name in tree2) {
-    if (tree1Names.indexOf(name) == -1)
-      continue;
-
-    intersectTree[name] = tree1[name] || tree2[name] || null;
+// build into an optimized static module
+Builder.prototype.build = function(expressionOrTree, outFile, opts) {
+  if (outFile && typeof outFile === 'object') {
+    opts = outFile;
+    outFile = undefined;
   }
 
-  return intersectTree;
-};
+  var self = this;
 
-// returns a new tree containing tree1 + tree2
-Builder.prototype.addTrees = function(tree1, tree2) {
-  var name;
-  var unionTree = {};
+  if (opts && opts.config)
+    this.config(opts.config);
 
-  for (name in tree2)
-    unionTree[name] = tree2[name] || tree1[name] || null;
+  var outputOpts = processOutputOpts(opts, { outFile: outFile });
+  
+  return Promise.resolve()
+  .then(function() {
+    if (typeof expressionOrTree != 'string')
+      return { tree: expressionOrTree };
 
-  for (name in tree1)
-    unionTree[name] = tree1[name] || tree2[name] || null;
-
-  return unionTree;
-};
-
-// returns a new tree containing tree1 - tree2
-Builder.prototype.subtractTrees = function(tree1, tree2) {
-  var name;
-  var subtractTree = {};
-
-  for (name in tree1)
-    subtractTree[name] = tree1[name];
-
-  for (name in tree2)
-    if (tree2[name])
-      delete subtractTree[name];
-
-  return subtractTree;
-};
-
-// given a tree, creates a depCache for it
-Builder.prototype.getDepCache = function(tree) {
-  var depCache = {};
-  Object.keys(tree).forEach(function(moduleName) {
-    var load = tree[moduleName];
-    if (load.deps.length)
-      depCache[moduleName] = load.deps.map(function(dep) {
-        return load.depMap[dep];
+    return traceExpression(self, expressionOrTree, processTraceOpts(opts));
+  })
+  .then(function(trace) {
+    return compileTree(self.loader, trace.tree, trace.entryPoints || [], processCompileOpts(opts, { static: true }), outputOpts, self.cache.compile)
+    .then(function(outputs) {
+      return writeOutputs(outputs, self.loader.baseURL, outputOpts);
+    })
+    .then(function(output) {
+      output.modules = Object.keys(trace.tree).filter(function(moduleName) {
+        return trace.tree[moduleName];
       });
+      return output;
+    });
   });
-  return depCache;
 };
+
+Builder.prototype.buildSFX = function() {
+  throw new TypeError('builder.buildSFX is now called builder.build, while builder.build has been renamed to builder.bundle.');
+};
+Builder.prototype.buildTree = function() {
+  throw new TypeError('builder.buildTree has been combined into builder.build and builder.bundle, which will now both take expressions or tree objects.');
+};
+
+// expose useful tree statics on the builder instance for ease-of-use
+Builder.prototype.intersectTrees = require('./arithmetic').intersectTrees;
+Builder.prototype.addTrees = require('./arithmetic').addTrees;
+Builder.prototype.subtractTrees = require('./arithmetic').subtractTrees;
 
 module.exports = Builder;

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -191,10 +191,7 @@ Builder.prototype.trace = function(expression, opts) {
   if (opts && opts.config)
     this.config(opts.config);
 
-  return traceExpression(this, expression, processTraceOpts(opts))
-  .then(function(trace) {
-    return trace.tree;
-  });
+  return traceExpression(this, expression, processTraceOpts(opts));
 };
 
 function processCompileOpts(options, defaults) {
@@ -303,18 +300,18 @@ Builder.prototype.bundle = function(expressionOrTree, outFile, opts) {
   return Promise.resolve()
   .then(function() {
     if (typeof expressionOrTree != 'string')
-      return { tree: expressionOrTree };
+      return expressionOrTree;
 
     return traceExpression(self, expressionOrTree, processTraceOpts(opts));
   })
-  .then(function(trace) {
-    return compileTree(self.loader, trace.tree, trace.entryPoints || [], processCompileOpts(opts), outputOpts, self.cache.compile)
+  .then(function(tree) {
+    return compileTree(self.loader, tree, processCompileOpts(opts), outputOpts, self.cache.compile)
     .then(function(outputs) {
       return writeOutputs(outputs, self.loader.baseURL, outputOpts);
     })
     .then(function(output) {
-      output.modules = Object.keys(trace.tree).filter(function(moduleName) {
-        return trace.tree[moduleName];
+      output.modules = Object.keys(tree).filter(function(moduleName) {
+        return tree[moduleName];
       });
       return output;
     });
@@ -340,23 +337,22 @@ Builder.prototype.build = function(expressionOrTree, outFile, opts) {
   return Promise.resolve()
   .then(function() {
     if (typeof expressionOrTree != 'string')
-      return { tree: expressionOrTree };
+      return expressionOrTree;
 
     return traceExpression(self, expressionOrTree, traceOpts);
   })
-  .then(function(trace) {
-
+  .then(function(tree) {
     // inline conditionals of the trace
-    return self.tracer.inlineConditions(trace.tree, traceOpts.conditions)
+    return self.tracer.inlineConditions(tree, traceOpts.conditions)
     .then(function(inlinedTree) {
-      return compileTree(self.loader, inlinedTree, trace.entryPoints || [], compileOpts, outputOpts, self.cache.compile)
+      return compileTree(self.loader, inlinedTree, compileOpts, outputOpts, self.cache.compile)
     })
     .then(function(outputs) {
       return writeOutputs(outputs, self.loader.baseURL, outputOpts);
     })
     .then(function(output) {
-      output.modules = Object.keys(trace.tree).filter(function(moduleName) {
-        return trace.tree[moduleName];
+      output.modules = Object.keys(tree).filter(function(moduleName) {
+        return tree[moduleName];
       });
       return output;
     });

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -186,7 +186,11 @@ Builder.prototype.compile = function(moduleName, outFile, opts) {
   opts.anonymous = true;
   
   var self = this;
-  return this.tracer.getLoadRecord(moduleName)
+
+  return Promise.resolve(self.loader.normalize(moduleName))
+  .then(function(moduleName) {
+    return self.tracer.getLoadRecord(getCanonicalName(self.loader, moduleName));
+  })
   .then(function(load) {
     return compileLoad(self.loader, load, opts);
   })
@@ -296,28 +300,18 @@ Builder.prototype.traceModule = function(moduleName) {
   var loader = this.loader;
 
   var self = this;
-
-  var System = loader.global.System;
-  loader.global.System = loader;
   
   return Promise.resolve(loader.normalize(moduleName))
   .then(function(_moduleName) {
     moduleName = getCanonicalName(loader, _moduleName);
-    return self.tracer.getAllLoadRecords(moduleName);
+    return self.tracer.getAllLoadRecords(moduleName, true, {});
   })
   .then(function(loads) {
-    loader.global.System = System;
-
-    if (moduleName == '@empty')
-      return {
-        moduleName: moduleName,
-        tree: loads
-      };
-
     // if it is a bundle, we just use a regex to extract the list of loads
     // as null records for subtraction arithmetic use only
     var thisLoad = loads[moduleName];
-    if (thisLoad.metadata.bundle) {
+
+    if (thisLoad && thisLoad.metadata.bundle) {
       namedRegisterRegEx.lastIndex = 0;
       var curMatch;
       while ((curMatch = namedRegisterRegEx.exec(thisLoad.source)))

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -171,12 +171,12 @@ function processTraceOpts(options, defaults) {
 
   // conditional tracing defaults
   if (typeof opts.browser == 'boolean' || typeof opts.node == 'boolean') {
-    var sysEnv = conditions['@system-env'] = conditions['@system-env'] || {};
+    var sysEnv = opts.conditions['@system-env'] = opts.conditions['@system-env'] || {};
 
     if (typeof opts.browser == 'boolean' && typeof opts.node != 'boolean')
-      opts.node = false;
+      opts.node = !opts.browser;
     if (typeof opts.node == 'boolean' && typeof opts.browser != 'boolean')
-      opts.browser = false;
+      opts.browser = !opts.node;
     
     sysEnv['browser'] = opts.browser;
     sysEnv['~browser'] = !opts.browser;

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -79,11 +79,13 @@ Builder.prototype.reset = function(baseLoader) {
   baseLoader = baseLoader || this.loader || System;
 
   var loader = this.loader = new baseLoader.constructor();
-  loader.constructor = baseLoader.constructor;
-  loader.baseURL = baseLoader.baseURL;
+  var pluginLoader = loader.pluginLoader = new baseLoader.constructor();
 
-  loader.normalize = baseLoader.normalize;
-  loader.normalizeSync = baseLoader.normalizeSync;
+  loader.constructor = pluginLoader.constructor = baseLoader.constructor;
+  loader.baseURL = pluginLoader.baseURL = baseLoader.baseURL;
+
+  loader.normalize = pluginLoader.normalize = baseLoader.normalize;
+  loader.normalizeSync = pluginLoader.normalizeSync = baseLoader.normalizeSync;
 
   // store original hooks for next reset
   loader.originalHooks = baseLoader.originalHooks || {
@@ -93,10 +95,16 @@ Builder.prototype.reset = function(baseLoader) {
     instantiate: baseLoader.instantiate
   };
 
-  loader.locate = loader.originalHooks.locate;
-  loader.fetch = loader.originalHooks.fetch;
-  loader.translate = loader.originalHooks.translate;
-  loader.instantiate = loader.originalHooks.instantiate;
+  loader.locate = pluginLoader.locate = loader.originalHooks.locate;
+  loader.fetch = pluginLoader.fetch = loader.originalHooks.fetch;
+  loader.translate = pluginLoader.translate = loader.originalHooks.translate;
+  loader.instantiate = pluginLoader.instantiate = loader.originalHooks.instantiate;
+
+  loaderConfig = loader.config;
+  loader.config = function(cfg) {
+    loaderConfig.call(loader, cfg);
+    loader.pluginLoader.config(cfg);
+  };
 
   loader.builder = true;
 
@@ -107,7 +115,7 @@ Builder.prototype.reset = function(baseLoader) {
   // useful for plugin duplications of hooks
   var fetchCache = {};
   var loaderFetch = loader.fetch;
-  loader.fetch = function(load) {
+  loader.fetch = pluginLoader.fetch = function(load) {
     if (fetchCache[load.name])
       return fetchCache[load.name];
 
@@ -116,7 +124,6 @@ Builder.prototype.reset = function(baseLoader) {
       return source;
     });
   };
-  loader.fetch.cached = true;
 
   // clear the cache
   this.setCache({});

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -142,7 +142,7 @@ Builder.prototype.loadConfigSync = function(configFile, saveForReset, ignoreBase
 Builder.prototype.config = function(config, saveForReset, ignoreBaseURL) {
   var cfg = {};
   for (var p in config) {
-    if (ignoreBaseURL && p == 'baseURL' || p == 'bundles')
+    if (ignoreBaseURL && p == 'baseURL' || p == 'bundles' || p == 'depCache')
       continue;
     cfg[p] = config[p];
   }
@@ -216,6 +216,8 @@ function processCompileOpts(options, defaults) {
     format: 'global',
     globalDeps: {},
     globalName: null,
+    // conditionalResolutions: {}, 
+    // can add a special object here that matches condition predicates to direct module names to use for sfx
 
     // this shouldn't strictly be a compile option,
     // but the cjs compiler needs it to do NODE_ENV optimization
@@ -332,16 +334,23 @@ Builder.prototype.build = function(expressionOrTree, outFile, opts) {
     this.config(opts.config);
 
   var outputOpts = processOutputOpts(opts, { outFile: outFile });
+  var traceOpts = processTraceOpts(opts);
+  var compileOpts = processCompileOpts(opts, { static: true });
   
   return Promise.resolve()
   .then(function() {
     if (typeof expressionOrTree != 'string')
       return { tree: expressionOrTree };
 
-    return traceExpression(self, expressionOrTree, processTraceOpts(opts));
+    return traceExpression(self, expressionOrTree, traceOpts);
   })
   .then(function(trace) {
-    return compileTree(self.loader, trace.tree, trace.entryPoints || [], processCompileOpts(opts, { static: true }), outputOpts, self.cache.compile)
+
+    // inline conditionals of the trace
+    return self.tracer.inlineConditions(trace.tree, traceOpts.conditions)
+    .then(function(inlinedTree) {
+      return compileTree(self.loader, inlinedTree, trace.entryPoints || [], compileOpts, outputOpts, self.cache.compile)
+    })
     .then(function(outputs) {
       return writeOutputs(outputs, self.loader.baseURL, outputOpts);
     })

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -62,7 +62,9 @@ function sfxEncoding(moduleName, encodings) {
 // compiledTree is load tree with "source" and "output" set
 exports.compileOutputs = compileOutputs;
 function compileOutputs(loader, tree, opts, sfxEntryPoints, cache) {
-  var modules = getTreeModulesPostOrder(tree, sfxEntryPoints);
+  var modules = getTreeModulesPostOrder(tree, sfxEntryPoints).filter(function(moduleName) {
+    return tree[moduleName];
+  });
 
   // if doing an sfx build, obscure module names first
   if (sfxEntryPoints && opts.sfxEncoding !== false) {
@@ -101,7 +103,7 @@ function compileOutputs(loader, tree, opts, sfxEntryPoints, cache) {
     modules.forEach(function(name) {
       var load = tree[name];
 
-      if (load === null)
+      if (load === true)
         throw new TypeError('"' + name + '" was defined via a bundle, so can only be used for subtraction or union operations.');
 
       // group plugin loads by plugin for bundle hook
@@ -195,7 +197,9 @@ function wrapSFXOutputs(loader, tree, outputs, sfxEntryPoints, opts) {
   if (opts.sfxFormat == 'es6')
     opts.sfxFormat = 'esm';
 
-  var modules = Object.keys(tree);
+  var modules = Object.keys(tree).filter(function(module) {
+    return tree[module];
+  });
 
   // determine compilers used
   modules.forEach(function(name) {

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -208,7 +208,7 @@ function wrapSFXOutputs(loader, tree, outputs, entryPoints, compileOpts) {
     // check all deps are present
     load.deps.forEach(function(dep) {
       var key = load.depMap[dep];
-      if (modules.indexOf(key) == -1 && key != '@empty') {
+      if (!(key in tree) && key[0] != '@') {
         if (compileOpts.format == 'esm')
           throw new TypeError('External SFX dependencies not yet supported for ES module SFX bundles. See https://github.com/systemjs/builder/issues/259.')
 

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -7,6 +7,7 @@ var createHash = require('crypto').createHash;
 var template = require('es6-template-strings');
 var getAlias = require('./utils').getAlias;
 var getTreeModulesPostOrder = require('./trace').getTreeModulesPostOrder;
+var extend = require('./utils').extend;
 
 var compilerMap = {
   'amd': '../compilers/amd',
@@ -16,229 +17,207 @@ var compilerMap = {
   'register': '../compilers/register'
 };
 
-function hashString(source) {
-  return createHash('md5').update(source).digest('hex');
+// create a compile hash based on path + source + metadata + compileOpts
+// one implication here is that plugins shouldn't rely on System.x checks
+// as these will not be cache-invalidated but within the bundle hook is fine
+function getCompileHash(load, compileOpts) {
+  return createHash('md5')
+  .update(JSON.stringify({
+    source: load.source,
+    metadata: load.metadata,
+    path: compileOpts.sourceMaps && load.path,
+
+    normalize: compileOpts.normalize,
+    anonymous: compileOpts.anonymous,
+    systemGlobal: compileOpts.systemGlobal,
+    static: compileOpts.static,
+    encodeNames: compileOpts.encodeNames,
+    sourceMaps: compileOpts.sourceMaps,
+    lowResSourceMaps: compileOpts.lowResSourceMaps
+  }))
+  .digest('hex');
 }
 
-function retrieveCachedOutput(cache, load) {
-  if (!cache)
-    return;
+function getEncoding(canonical, encodings) {
+  // dont encode system modules
+  if (canonical[0] == '@')
+    return canonical;
 
-  var entry = cache[load.name];
-  if (!entry)
-    return;
+  // return existing encoding if present
+  if (encodings[canonical])
+    return encodings[canonical];
 
-  return hashString(JSON.stringify(load)) === entry.sourceHash && entry.output;
-}
+  // search for the first available key
+  var highestEncoding = 0;
+  Object.keys(encodings).forEach(function(canonical) {
+    var encoding = encodings[canonical];
+    highestEncoding = Math.max(parseInt(encoding, '16'), highestEncoding);
+  });
 
-function updateCacheEntry(cache, load, output) {
-  if (!cache)
-    return;
+  highestEncoding++;
 
-  cache[load.name] = {
-    sourceHash: hashString(JSON.stringify(load)),
-    output: output
-  };
+  return encodings[canonical] = highestEncoding.toString(16);
 }
 
 exports.compileLoad = compileLoad;
-function compileLoad(loader, load, opts) {
+function compileLoad(loader, load, compileOpts, cache) {
   var format = load.metadata.format;
 
-  if (format in compilerMap)
-    return require(compilerMap[format]).compile(load, opts, loader);
-  else if (format == 'defined')
-    return { source: '' };
-  else
-    throw new Error("Unknown module format " + format);
+  if (format == 'defined')
+    return Promise.resolve({ source:  compileOpts.systemGlobal + '.register("' + load.name + '", [], function() {});\n' });
+
+  if (format in compilerMap) {
+    // use cached if we have it
+    var cached = cache.loads[load.name];
+    if (cached && cached.hash == getCompileHash(load, compileOpts))
+      return Promise.resolve(cached.output);
+
+    // for static encoding, create a new load record
+    // with the encodings included
+    if (compileOpts.encodeNames) {
+      load = extend({}, load);
+      load.name = getEncoding(load.name, cache.encodings);
+      var depMap = {};
+      Object.keys(load.depMap).forEach(function(dep) {
+        depMap[dep] = getEncoding(load.depMap[dep], cache.encodings);
+      });
+      load.depMap = depMap;
+    }
+
+    return Promise.resolve(require(compilerMap[format]).compile(load, compileOpts, loader))
+    .then(function(output) {
+      // store compiled output in cache
+      cache.loads[load.name] = {
+        hash: getCompileHash(load, compileOpts),
+        output: output
+      };
+
+      return output;
+    })
+  }
+
+  return Promise.reject(new TypeError('Unknown module format ' + format));
 }
 
-function sfxEncoding(moduleName, encodings) {
-  if (moduleName == '@empty')
-    return moduleName;
-  return encodings[moduleName] || (encodings[moduleName] = Object.keys(encodings).length.toString(16));
-}
-
-// compiledTree is load tree with "source" and "output" set
-exports.compileOutputs = compileOutputs;
-function compileOutputs(loader, tree, opts, sfxEntryPoints, cache) {
-  var modules = getTreeModulesPostOrder(tree, sfxEntryPoints).filter(function(moduleName) {
-    return tree[moduleName];
+exports.compileTree = compileTree;
+function compileTree(loader, tree, entryPoints, compileOpts, outputOpts, cache) {
+  // sort in graph order, filter modules to actually built loads (excluding conditionals, build: false)
+  var modules = getTreeModulesPostOrder(tree, entryPoints).filter(function(moduleName) {
+    return tree[moduleName] && !tree[moduleName].conditional;
   });
 
-  // if doing an sfx build, obscure module names first
-  if (sfxEntryPoints && opts.sfxEncoding !== false) {
-    var encodings = {};
+  if (compileOpts.encodeNames)
+    entryPoints = entryPoints.map(function(name) {
+      return getEncoding(name, cache.encodings)
+    });
 
-    sfxEntryPoints = sfxEntryPoints.map(function(name) {
-      return sfxEncoding(name, encodings);
-    });
-    modules = modules.map(function(module) {
-      var encoded = sfxEncoding(module, encodings);
-      var load = tree[module];
-      delete tree[module];
-      tree[encoded] = load;
-      load.name = encoded;
-      load.originalDepMap = load.depMap;
-      load.depMap = {};
-      Object.keys(load.originalDepMap).forEach(function(dep) {
-        load.depMap[dep] = sfxEncoding(load.originalDepMap[dep], encodings);
-      });
-      return encoded;
-    });
-  }
+  var outputs = [];
 
   // store plugins with a bundle hook to allow post-processing
   var pluginLoads = {};
   var compilers = {};
 
-  // output array to create
-  var outputs = [];
-
-  return Promise.resolve()
-
-  // pre-processing
-  .then(function() {
-
-    modules.forEach(function(name) {
+  // create load output objects
+  return Promise.all(modules.map(function(name) {
+    return Promise.resolve()
+    .then(function() {
       var load = tree[name];
 
       if (load === true)
-        throw new TypeError('"' + name + '" was defined via a bundle, so can only be used for subtraction or union operations.');
+        throw new TypeError(name + ' was defined via a bundle, so can only be used for subtraction or union operations.');
 
-      // group plugin loads by plugin for bundle hook
-      var plugin = load.metadata.loaderModule;
-      if (plugin) {
-        if (load.metadata.loaderModule.build === false && sfxEntryPoints)
-          throw new TypeError("Plugin '" + load.metadata.loader + '" does not support SFX builds.');
+      if (compileOpts.static && load.runtimePlugin)
+        throw new TypeError('Plugin ' + load.runtimePlugin + ' does not support static builds, compiling ' + load.name + '.');
 
-        if (plugin.bundle && load.metadata.build !== false) {
-          var loads = pluginLoads[load.metadata.loader] = pluginLoads[load.metadata.loader] || [];
-          loads.push(load);
-        }
-      }
+      // store plugin loads for bundle hook
+      if (load.metadata.loader && load.metadata.loaderModule.bundle)
+        (pluginLoads[load.metadata.loader] = pluginLoads[load.metadata.loader] || []).push(load);
+
+      return compileLoad(loader, tree[name], compileOpts, cache);
+    })
+    .then(function(output) {
+      outputs.push(output);
     });
-  })
+  }))
 
-  // create load output objects
-  .then(function() {
-    return Promise.all(modules.map(function(name) {
-      var load = tree[name];
-
-      if (load.metadata.loaderModule && load.metadata.loaderModule.bundle)
-        return;
-
-      var output = retrieveCachedOutput(cache, load);
-      if (output) {
-        outputs.push(output);
-        return;
-      }
-
-      return Promise.resolve(compileLoad(loader, load, opts))
-      .then(function(output) {
-        updateCacheEntry(cache, load, output);
-        outputs.push(output);
-      });
-    }));
-  })
-
-  // create bundle plugin outputs
+  // run plugin bundle hook
   .then(function() {
     return Promise.all(Object.keys(pluginLoads).map(function(pluginName) {
       var loads = pluginLoads[pluginName];
       var bundle = loads[0].metadata.loaderModule.bundle;
 
-      return Promise.resolve(bundle.call(loader.pluginLoader, loads, opts))
+      return Promise.resolve(bundle.call(loader.pluginLoader, loads, compileOpts, outputOpts))
       .then(function(output) {
-        function scopeSystem(output) {
-          if (!opts.sfx)
-            return output;
-          if (typeof output == 'object')
-            output.source = scopeSystem(output.source);
-          output = output.replace(/System\.register/g, '$__System.register');
-          return output;
-        }
-
-        if (output instanceof Array) {
-          output = output.map(scopeSystem);
+        if (output instanceof Array)
           outputs = outputs.concat(output);
-        }
-        else {
-          outputs.push(scopeSystem(output));
-        }
+        else
+          outputs.push(output);
       });
     }));
   })
-
-  // if any module in the bundle is AMD, add a "bundle" meta to the bundle
-  // this can be deprecated if https://github.com/systemjs/builder/issues/264 lands
   .then(function() {
-    var hasAMD = modules.some(function(name) {
-      return tree[name].metadata.format == 'amd';
-    });
 
-    if (hasAMD)
+    // if any module in the bundle is AMD, add a "bundle" meta to the bundle
+    // this can be deprecated if https://github.com/systemjs/builder/issues/264 lands
+    if (modules.some(function(name) {
+          return tree[name].metadata.format == 'amd';
+        }))
       outputs.unshift('"bundle";');
-  })
 
-  .then(function() {
-    if (sfxEntryPoints)
-      return wrapSFXOutputs(loader, tree, outputs, sfxEntryPoints, opts);
+    // static bundle wraps with a self-executing loader
+    if (compileOpts.static)
+      return wrapSFXOutputs(loader, tree, outputs, entryPoints, compileOpts);
     else
       return outputs;
   });
 }
 
 exports.wrapSFXOutputs = wrapSFXOutputs;
-function wrapSFXOutputs(loader, tree, outputs, sfxEntryPoints, opts) {
+function wrapSFXOutputs(loader, tree, outputs, entryPoints, compileOpts) {
   var compilers = {};
 
   // NB deprecate
-  if (opts.sfxFormat == 'es6')
-    opts.sfxFormat = 'esm';
+  if (compileOpts.format == 'es6')
+    compileOpts.format = 'esm';
 
   var modules = Object.keys(tree).filter(function(module) {
-    return tree[module];
+    return tree[module] && !tree[module].conditional;
   });
 
   // determine compilers used
   modules.forEach(function(name) {
-    var load = tree[name];
-    if (load.metadata.build !== false) {
-      var format = load.metadata.format;
-      if (format == 'defined')
-        return;
-      // NB to be deprecated with SystemJS 0.19
-      if (format == 'es6')
-        format = 'esm';
-      if (!(load.metadata.format in compilerMap))
-        throw new Error(name + ' has format set to "' + load.metadata.format + '", which is not valid. Must be one of "esm", "amd", "cjs", "global" or "register".');
+    compilers[tree[name].metadata.format] = true;
+  });
 
-      compilers[load.metadata.format] = true;
-    }
+  // include compiler helpers at the beginning of outputs
+  Object.keys(compilerMap).forEach(function(format) {
+    if (!compilers[format])
+      return;
+    var compiler = require(compilerMap[format]);
+    if (compiler.sfx)
+      outputs.unshift(compiler.sfx(loader));
   });
 
   // determine if the SFX bundle has any external dependencies it relies on
   var externalDeps = [];
   var externalDepIds = [];
-  var sfxGlobals = [];
+  var globalDeps = [];
   modules.forEach(function(name) {
     var load = tree[name];
 
     // check all deps are present
     load.deps.forEach(function(dep) {
       var key = load.depMap[dep];
-      var originalKey = (load.originalDepMap || load.depMap)[dep];
       if (modules.indexOf(key) == -1 && key != '@empty') {
-        if (opts.sfxFormat == 'esm')
+        if (compileOpts.format == 'esm')
           throw new TypeError('External SFX dependencies not yet supported for ES module SFX bundles. See https://github.com/systemjs/builder/issues/259.')
 
-        var alias = getAlias(loader, originalKey);
+        var alias = getAlias(loader, key);
 
-        if (opts.sfxFormat == 'global') {
-          if (!opts.sfxGlobals[alias])
-            throw new TypeError('Global SFX bundle dependency "' + alias + '" (' + originalKey + ') must be configured to an environment global via the sfxGlobals option.');
-          sfxGlobals.push(opts.sfxGlobals[alias]);
+        if (compileOpts.format == 'global') {
+          if (!compileOpts.globalDeps[alias])
+            throw new TypeError('Global SFX bundle dependency "' + alias + '" (' + key + ') must be configured to an environment global via the globalDeps option.');
+          globalDeps.push(compileOpts.globalDeps[alias]);
         }
 
         externalDeps.push(alias);
@@ -247,30 +226,20 @@ function wrapSFXOutputs(loader, tree, outputs, sfxEntryPoints, opts) {
     });
   });
 
-  // include compiler helpers at the beginning of outputs
-  Object.keys(compilers).forEach(function(format) {
-    compiler = require(compilerMap[format]);
-    if (compiler.sfx)  {
-      var sfx = compiler.sfx(loader);
-      if (sfx)
-        outputs.unshift(sfx);
-    }
-  });
-
   // next wrap with the core code
   return asp(fs.readFile)(path.resolve(__dirname, '../templates/sfx-core.js'))
   .then(function(sfxcore) {
-    outputs.unshift(sfxcore.toString(), "(['" + sfxEntryPoints.join('\', \'') + "'], " + JSON.stringify(externalDepIds) + ", function($__System) {\n");
+    outputs.unshift(sfxcore.toString(), "(['" + entryPoints.join('\', \'') + "'], " + JSON.stringify(externalDepIds) + ", function(" + compileOpts.systemGlobal + ") {\n");
 
     outputs.push("})");
-    return asp(fs.readFile)(path.resolve(__dirname, '../templates/sfx-' + opts.sfxFormat + '.js'))
+    return asp(fs.readFile)(path.resolve(__dirname, '../templates/sfx-' + compileOpts.format + '.js'))
   })
   // then include the sfx module format wrapper
   .then(function(formatWrapper) {
     outputs.push(template(formatWrapper.toString(), {
       deps: externalDeps,
-      sfxGlobals: sfxGlobals,
-      sfxGlobalName: opts.sfxGlobalName
+      globalDeps: globalDeps,
+      globalName: compileOpts.globalName
     }));
   })
   // then wrap with the runtime
@@ -278,7 +247,7 @@ function wrapSFXOutputs(loader, tree, outputs, sfxEntryPoints, opts) {
     var usesBabelHelpersGlobal = modules.some(function(name) {
       return tree[name].metadata.usesBabelHelpersGlobal;
     });
-    if (opts.runtime && usesBabelHelpersGlobal)
+    if (compileOpts.runtime && usesBabelHelpersGlobal)
       return getModuleSource(loader, 'babel/external-helpers')
       .then(function(source) {
         outputs.unshift(source);
@@ -288,7 +257,7 @@ function wrapSFXOutputs(loader, tree, outputs, sfxEntryPoints, opts) {
     var usesTraceurRuntimeGlobal = modules.some(function(name) {
       return tree[name].metadata.usesTraceurRuntimeGlobal;
     });
-    if (opts.runtime && usesTraceurRuntimeGlobal)
+    if (compileOpts.runtime && usesTraceurRuntimeGlobal)
       return getModuleSource(loader, 'traceur-runtime')
       .then(function(source) {
         // protect System global clobbering
@@ -297,16 +266,16 @@ function wrapSFXOutputs(loader, tree, outputs, sfxEntryPoints, opts) {
   })
   // for AMD, CommonJS and global SFX outputs, add a "format " meta to support SystemJS loading
   .then(function() {
-    if (opts.sfxGlobalName)
-      outputs.unshift('"exports ' + opts.sfxGlobalName + '";');
+    if (compileOpts.globalName)
+      outputs.unshift('"exports ' + compileOpts.globalName + '";');
 
-    if (opts.sfxFormat == 'global') {
-      for (var g in opts.sfxGlobals)
-        outputs.unshift('"globals.' + opts.sfxGlobals[g] + ' ' + g + '";');
+    if (compileOpts.format == 'global') {
+      for (var g in compileOpts.globalDeps)
+        outputs.unshift('"globals.' + compileOpts.globalDeps[g] + ' ' + g + '";');
     }
 
-    if (opts.sfxFormat == 'amd' || opts.sfxFormat == 'cjs' || opts.sfxFormat == 'global')
-      outputs.unshift('"format ' + opts.sfxFormat + '";');
+    if (compileOpts.format == 'amd' || compileOpts.format == 'cjs' || compileOpts.format == 'global')
+      outputs.unshift('"format ' + compileOpts.format + '";');
   })
   .then(function() {
     return outputs;

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -145,7 +145,7 @@ function compileOutputs(loader, tree, opts, sfxEntryPoints, cache) {
       var loads = pluginLoads[pluginName];
       var bundle = loads[0].metadata.loaderModule.bundle;
 
-      return Promise.resolve(bundle.call(loader, loads, opts))
+      return Promise.resolve(bundle.call(loader.pluginLoader, loads, opts))
       .then(function(output) {
         function scopeSystem(output) {
           if (!opts.sfx)

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -6,7 +6,7 @@ var url = require('url');
 var createHash = require('crypto').createHash;
 var template = require('es6-template-strings');
 var getAlias = require('./utils').getAlias;
-var postOrderTraverseTree = require('./utils').postOrderTraverseTree;
+var getTreeModulesPostOrder = require('./utils').getTreeModulesPostOrder;
 
 var compilerMap = {
   'amd': '../compilers/amd',
@@ -62,7 +62,7 @@ function sfxEncoding(moduleName, encodings) {
 // compiledTree is load tree with "source" and "output" set
 exports.compileOutputs = compileOutputs;
 function compileOutputs(loader, tree, opts, sfxEntryPoints, cache) {
-  var modules = postOrderTraverseTree(tree, sfxEntryPoints);
+  var modules = getTreeModulesPostOrder(tree, sfxEntryPoints);
 
   // if doing an sfx build, obscure module names first
   if (sfxEntryPoints && opts.sfxEncoding !== false) {

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -100,9 +100,12 @@ function compileLoad(loader, load, compileOpts, cache) {
 }
 
 exports.compileTree = compileTree;
-function compileTree(loader, tree, entryPoints, compileOpts, outputOpts, cache) {
+function compileTree(loader, tree, compileOpts, outputOpts, cache) {
   // sort in graph order, filter modules to actually built loads (excluding conditionals, build: false)
-  var modules = getTreeModulesPostOrder(tree, entryPoints).filter(function(moduleName) {
+  var ordered = getTreeModulesPostOrder(tree);
+  // get entrypoints from graph algorithm
+  var entryPoints = ordered.entryPoints;
+  var modules = ordered.modules.filter(function(moduleName) {
     return tree[moduleName] && !tree[moduleName].conditional;
   });
 

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -6,7 +6,7 @@ var url = require('url');
 var createHash = require('crypto').createHash;
 var template = require('es6-template-strings');
 var getAlias = require('./utils').getAlias;
-var getTreeModulesPostOrder = require('./utils').getTreeModulesPostOrder;
+var getTreeModulesPostOrder = require('./trace').getTreeModulesPostOrder;
 
 var compilerMap = {
   'amd': '../compilers/amd',

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -62,7 +62,7 @@ function sfxEncoding(moduleName, encodings) {
 // compiledTree is load tree with "source" and "output" set
 exports.compileOutputs = compileOutputs;
 function compileOutputs(loader, tree, opts, sfxEntryPoints, cache) {
-  var modules = Object.keys(tree);
+  var modules = postOrderTraverseTree(tree, loader, sfxEntryPoints);
 
   // if doing an sfx build, obscure module names first
   if (sfxEntryPoints && opts.sfxEncoding !== false) {

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -6,6 +6,7 @@ var url = require('url');
 var createHash = require('crypto').createHash;
 var template = require('es6-template-strings');
 var getAlias = require('./utils').getAlias;
+var postOrderTraverseTree = require('./utils').postOrderTraverseTree;
 
 var compilerMap = {
   'amd': '../compilers/amd',
@@ -174,7 +175,7 @@ function compileOutputs(loader, tree, opts, sfxEntryPoints, cache) {
       return tree[name].metadata.format == 'amd';
     });
 
-    if (hasAMD) 
+    if (hasAMD)
       outputs.unshift('"bundle";');
   })
 
@@ -294,7 +295,7 @@ function wrapSFXOutputs(loader, tree, outputs, sfxEntryPoints, opts) {
   .then(function() {
     if (opts.sfxGlobalName)
       outputs.unshift('"exports ' + opts.sfxGlobalName + '";');
-    
+
     if (opts.sfxFormat == 'global') {
       for (var g in opts.sfxGlobals)
         outputs.unshift('"globals.' + opts.sfxGlobals[g] + ' ' + g + '";');

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -62,7 +62,7 @@ function sfxEncoding(moduleName, encodings) {
 // compiledTree is load tree with "source" and "output" set
 exports.compileOutputs = compileOutputs;
 function compileOutputs(loader, tree, opts, sfxEntryPoints, cache) {
-  var modules = postOrderTraverseTree(tree, loader, sfxEntryPoints);
+  var modules = postOrderTraverseTree(tree, sfxEntryPoints);
 
   // if doing an sfx build, obscure module names first
   if (sfxEntryPoints && opts.sfxEncoding !== false) {

--- a/lib/output.js
+++ b/lib/output.js
@@ -4,7 +4,8 @@ var fs = require('fs');
 var Promise = require('rsvp').Promise;
 var asp = require('rsvp').denodeify;
 
-var coercePath = require('./utils').coercePath;
+var fromFileURL = require('./utils').fromFileURL;
+var toFileURL = require('./utils').toFileURL;
 
 function countLines(str) {
   return str.split(/\r\n|\r|\n/).length;
@@ -26,9 +27,6 @@ function processOutputs(outputs) {
 
   var sources = outputObj.sources = [];
   var sourceMapsWithOffsets = outputObj.sourceMapsWithOffsets = [];
-
-  if (!outputs)
-    return outputObj;
 
   outputs.forEach(function(output) {
     var source;
@@ -55,20 +53,13 @@ function processOutputs(outputs) {
   return outputObj;
 }
 
-function createOutput(outputs, outFile, outputPath, outputOpts) {
-  outFile = outFile && path.resolve(outFile);
+function createOutput(outFile, outputs, basePath, sourceMaps, sourceMapContents) {
   var concatenateSourceMaps = require('./sourcemaps').concatenateSourceMaps;
-  // process output
-  var sourceMap;
-  var onWindows =  process.platform.match(/^win/);
-  var outputURL = (onWindows ? 'file://' : 'file:/') + outputPath;
 
   var outputObj = processOutputs(outputs);
 
-  if (outputOpts.sourceMaps && outputObj.sourceMapsWithOffsets.length) {
-    var mapsWithOffsets = outputObj.sourceMapsWithOffsets;
-    sourceMap = concatenateSourceMaps(outFile, mapsWithOffsets, outputURL, outputOpts.sourceMapContents);
-  }
+  if (sourceMaps)
+    var sourceMap = concatenateSourceMaps(outFile, outputObj.sourceMapsWithOffsets, basePath, sourceMapContents);
 
   var output = outputObj.sources.join('\n');
 
@@ -122,55 +113,51 @@ function minify(output, fileName, mangle, globalDefs) {
   return output;
 }
 
-function writeOutputFile(outputOpts, output, basePath) {
-  var sourceMapFile;
-  if (outputOpts.sourceMaps && output.sourceMap) {
-    sourceMapFile = path.basename(outputOpts.outFile) + '.map';
-    output.source += '\n//# sourceMappingURL=' + sourceMapFile;
-  }
+function writeOutputFile(outFile, source, sourceMap) {
+  var outDir = path.dirname(outFile);
 
-  return asp(mkdirp)(path.dirname(path.resolve(basePath, outputOpts.outFile)))
+  return asp(mkdirp)(path.dirname(outFile))
   .then(function() {
-    if (!output.sourceMap || !outputOpts.sourceMaps) return;
-    var sourceMapPath = path.resolve(basePath, path.dirname(outputOpts.outFile), sourceMapFile);
-    return asp(fs.writeFile)(sourceMapPath, output.sourceMap);
+    if (!sourceMap)
+      return;
+
+    var sourceMapFileName = path.basename(outFile) + '.map';
+    source += '\n//# sourceMappingURL=' + sourceMapFileName;
+    
+    return asp(fs.writeFile)(path.resolve(outDir, sourceMapFileName), sourceMap);
   })
   .then(function() {
-    var sourcePath = path.resolve(basePath, outputOpts.outFile);
-    return asp(fs.writeFile)(sourcePath, output.source);
+    return asp(fs.writeFile)(outFile, source);
   });
 }
 
 exports.inlineSourceMap = inlineSourceMap;
-function inlineSourceMap(output) {
-  return output.source +
-    '\n//# sourceMappingURL=data:application/json;base64,' +
-    new Buffer(output.sourceMap.toString()).toString('base64');
+function inlineSourceMap(source, sourceMap) {
+  if (!sourceMap)
+    throw new Error('NOTHING TO INLINE');
+  return source + '\n//# sourceMappingURL=data:application/json;base64,'
+      + new Buffer(sourceMap.toString()).toString('base64');
 }
 
 exports.writeOutputs = function(outputs, baseURL, outputOpts) {
-  var basePath = coercePath(baseURL);
-  var outputPath;
+  var outFile = outputOpts.outFile && path.resolve(outputOpts.outFile);
+  var basePath = fromFileURL(baseURL);
+  var fileName = path.basename(outFile) || 'output.js';
 
-  if (outputOpts.outFile) {
-    outputOpts.outFile = path.relative(basePath, path.resolve(outputOpts.outFile));
-    outputPath = path.dirname(path.resolve(basePath, outputOpts.outFile));
-  }
-  else
-    outputPath = basePath;
-
-  var output = createOutput(outputs, outputOpts.outFile, outputPath, outputOpts);
+  var output = createOutput(outFile || path.resolve(basePath, fileName), outputs, basePath, outputOpts.sourceMaps, outputOpts.sourceMapContents);
 
   if (outputOpts.minify)
-    output = minify(output, outputOpts.outFile, outputOpts.mangle, outputOpts.globalDefs);
+    output = minify(output, fileName, outputOpts.mangle, outputOpts.globalDefs);
 
   if (outputOpts.sourceMaps == 'inline') {
-    output.source = inlineSourceMap(output);
+    output.source = inlineSourceMap(output.source, output.sourceMap);
     output.sourceMap = undefined;
   }
 
-  if (outputOpts.outFile)
-    return writeOutputFile(outputOpts, output, basePath).then(function() { return output; });
-  else
+  if (!outputOpts.outFile)
     return Promise.resolve(output);
+
+  return writeOutputFile(outFile, output.source, output.sourceMap).then(function() {
+    return output;
+  });
 };

--- a/lib/output.js
+++ b/lib/output.js
@@ -55,7 +55,7 @@ function processOutputs(outputs) {
   return outputObj;
 }
 
-function createOutput(outputs, outFile, outputPath, opts) {
+function createOutput(outputs, outFile, outputPath, outputOpts) {
   outFile = outFile && path.resolve(outFile);
   var concatenateSourceMaps = require('./sourcemaps').concatenateSourceMaps;
   // process output
@@ -65,9 +65,9 @@ function createOutput(outputs, outFile, outputPath, opts) {
 
   var outputObj = processOutputs(outputs);
 
-  if (opts.sourceMaps && outputObj.sourceMapsWithOffsets.length) {
+  if (outputOpts.sourceMaps && outputObj.sourceMapsWithOffsets.length) {
     var mapsWithOffsets = outputObj.sourceMapsWithOffsets;
-    sourceMap = concatenateSourceMaps(outFile, mapsWithOffsets, outputURL, opts.sourceMapContents);
+    sourceMap = concatenateSourceMaps(outFile, mapsWithOffsets, outputURL, outputOpts.sourceMapContents);
   }
 
   var output = outputObj.sources.join('\n');
@@ -122,21 +122,21 @@ function minify(output, fileName, mangle, globalDefs) {
   return output;
 }
 
-function writeOutputFile(opts, output, basePath) {
+function writeOutputFile(outputOpts, output, basePath) {
   var sourceMapFile;
-  if (opts.sourceMaps && output.sourceMap) {
-    sourceMapFile = path.basename(opts.outFile) + '.map';
+  if (outputOpts.sourceMaps && output.sourceMap) {
+    sourceMapFile = path.basename(outputOpts.outFile) + '.map';
     output.source += '\n//# sourceMappingURL=' + sourceMapFile;
   }
 
-  return asp(mkdirp)(path.dirname(path.resolve(basePath, opts.outFile)))
+  return asp(mkdirp)(path.dirname(path.resolve(basePath, outputOpts.outFile)))
   .then(function() {
-    if (!output.sourceMap || !opts.sourceMaps) return;
-    var sourceMapPath = path.resolve(basePath, path.dirname(opts.outFile), sourceMapFile);
+    if (!output.sourceMap || !outputOpts.sourceMaps) return;
+    var sourceMapPath = path.resolve(basePath, path.dirname(outputOpts.outFile), sourceMapFile);
     return asp(fs.writeFile)(sourceMapPath, output.sourceMap);
   })
   .then(function() {
-    var sourcePath = path.resolve(basePath, opts.outFile);
+    var sourcePath = path.resolve(basePath, outputOpts.outFile);
     return asp(fs.writeFile)(sourcePath, output.source);
   });
 }
@@ -148,29 +148,29 @@ function inlineSourceMap(output) {
     new Buffer(output.sourceMap.toString()).toString('base64');
 }
 
-exports.writeOutputs = function(opts, outputs, baseURL) {
+exports.writeOutputs = function(outputs, baseURL, outputOpts) {
   var basePath = coercePath(baseURL);
   var outputPath;
 
-  if (opts.outFile) {
-    opts.outFile = path.relative(basePath, path.resolve(opts.outFile));
-    outputPath = path.dirname(path.resolve(basePath, opts.outFile));
+  if (outputOpts.outFile) {
+    outputOpts.outFile = path.relative(basePath, path.resolve(outputOpts.outFile));
+    outputPath = path.dirname(path.resolve(basePath, outputOpts.outFile));
   }
   else
     outputPath = basePath;
 
-  var output = createOutput(outputs, opts.outFile, outputPath, opts);
+  var output = createOutput(outputs, outputOpts.outFile, outputPath, outputOpts);
 
-  if (opts.minify)
-    output = minify(output, opts.outFile, opts.mangle, opts.globalDefs);
+  if (outputOpts.minify)
+    output = minify(output, outputOpts.outFile, outputOpts.mangle, outputOpts.globalDefs);
 
-  if (opts.sourceMaps == 'inline') {
+  if (outputOpts.sourceMaps == 'inline') {
     output.source = inlineSourceMap(output);
     output.sourceMap = undefined;
   }
 
-  if (opts.outFile)
-    return writeOutputFile(opts, output, basePath).then(function() { return output; });
+  if (outputOpts.outFile)
+    return writeOutputFile(outputOpts, output, basePath).then(function() { return output; });
   else
     return Promise.resolve(output);
 };

--- a/lib/sourcemaps.js
+++ b/lib/sourcemaps.js
@@ -1,9 +1,9 @@
 var sourceMap = require('source-map');
-var traceur = require('traceur');
 var path = require('path');
 var fs = require('fs');
-var filePath = require('./utils').filePath;
-var isFileURL = require('./utils').isFileURL;
+
+var toFileURL = require('./utils').toFileURL;
+var fromFileURL = require('./utils').fromFileURL;
 
 var wrapSourceMap = function(map) {
   return new sourceMap.SourceMapConsumer(map);
@@ -26,17 +26,24 @@ function getMapObject(map) {
   }
 }
 
-exports.concatenateSourceMaps = function(sourceFilename, mapsWithOffsets, sourceRoot, includeSourcesContent) {
-  var contentsBySource = includeSourcesContent ? {} : null;
+function isFileURL(url) {
+  return url.substr(0, 8) == 'file:///';
+}
+
+exports.concatenateSourceMaps = function(outFile, mapsWithOffsets, basePath, sourceMapContents) {
   var generated = new sourceMap.SourceMapGenerator({
-    file: sourceFilename
+    file: path.basename(outFile)
   });
+
+  var outPath = path.dirname(outFile);
+
+  var contentsBySource = sourceMapContents ? {} : null;
 
   mapsWithOffsets.forEach(function(pair) {
     var offset = pair[0];
     var map = getMapObject(pair[1]);
 
-    if (includeSourcesContent && map.sourcesContent) {
+    if (sourceMapContents && map.sourcesContent) {
       for (var i=0; i<map.sources.length; i++) {
         var source = (map.sourceRoot || '') + map.sources[i];
         if (!source.match(/\/@traceur/)) {
@@ -64,36 +71,33 @@ exports.concatenateSourceMaps = function(sourceFilename, mapsWithOffsets, source
           line: mapping.originalLine,
           column: mapping.originalColumn
         },
-        source: mapping.source
+        source: mapping.source,
+        name: mapping.name
       });
     });
   });
 
-  // convert from library internals format to canonical
+  // normalize source paths and inject sourcesContent if necessary
   var normalized = JSON.parse(JSON.stringify(generated));
-  var sourcePath;
 
-  if (includeSourcesContent) {
+  normalized.sources = normalized.sources.map(function(source) {
+    if (isFileURL(source))
+      source = fromFileURL(source);
+
+    return path.relative(outPath, path.resolve(basePath, source)).replace(/\\/g, '/');
+  });
+
+  if (sourceMapContents) {
     normalized.sourcesContent = normalized.sources.map(function(source) {
-    //if (contentsBySource[source])
-      //return contentsBySource[source];
+      //if (contentsBySource[source])
+      //  return contentsBySource[source];
 
-    sourcePath = filePath(source);
-    if (sourcePath)
-      try { return fs.readFileSync(sourcePath).toString(); } catch (e) {}
+      try { return fs.readFileSync(path.resolve(basePath, source)).toString(); } catch (e) {}
 
-    // remove this is optimistic return is reliable
-    return contentsBySource[source];
+      // remove this if optimistic return is reliable
+      return contentsBySource[source];
     });
   }
-
-  var rootIsPath = isFileURL(sourceRoot);
-  normalized.sources = normalized.sources.map(function(source) {
-    if (rootIsPath && isFileURL(source))
-      return path.relative(sourceRoot, source).replace(/\\/g, '/');
-    else
-      return source;
-  });
 
   return JSON.stringify(normalized);
 };

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -242,11 +242,14 @@ Trace.prototype.getLoadRecord = function(canonical) {
           return load;
         });
       });
-    }
+    } 
 
     // -- trace loader hooks --
+    var curHook = 'locate';
     return Promise.resolve(loader.locate({ name: normalized, metadata: load.metadata = {}}))
     .then(function(address) {
+      curHook = '';
+
       // build: false build config - null load record
       if (load.metadata.build === false)
         return false;
@@ -261,16 +264,20 @@ Trace.prototype.getLoadRecord = function(canonical) {
 
       load.path = path.relative(fromFileURL(loader.baseURL), fromFileURL(address));
 
+      curHook = 'fetch';
       return Promise.resolve(loader.fetch({ name: normalized, metadata: load.metadata, address: address }))
       .then(function(source) {
         load.originalSource = source;
+        curHook = 'translate';
         return loader.translate({ name: normalized, metadata: load.metadata, address: address, source: source });
       })
       .then(function(source) {
         load.source = source;
+        curHook = 'instantiate';
         return loader.instantiate({ name: normalized, metadata: load.metadata, address: address, source: source });
       })
       .then(function(result) {
+        curHook = '';
         if (!result)
           throw new TypeError('Native ES Module builds not supported. Ensure transpilation is included in the loader pipeline.');
 
@@ -284,6 +291,26 @@ Trace.prototype.getLoadRecord = function(canonical) {
             load.depMap[dep] = getCanonicalName(loader, normalized);
           });
         }));
+      })
+      .catch(function(err) {
+        if (!curHook)
+          return;
+
+        var msg = 'Error running ' + curHook + ' hook for ' + canonical + ' at ' + normalized;
+
+        // rethrow loader hook errors with the hook information
+        var newErr;
+        if (err instanceof Error) {
+          var newErr = new Error(err.message, err.fileName, err.lineNumber);
+          // node errors only look correct with the stack modified
+          newErr.message = err.message;
+          newErr.stack = err.stack + '\n\t' + msg;
+        }
+        else {
+          newErr = err + '\n\t' + msg;
+        }
+
+        throw newErr;
       })
       .then(function() {
         // remove unnecessary metadata for trace

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -24,7 +24,7 @@ Trace.prototype.getLoadRecord = function(canonical) {
 
   // modules starting with "@" are assumed system modules
   if (canonical.substr(0, 1) == '@')
-    return Promise.resolve(null);
+    return Promise.resolve(false);
 
   if (loads[canonical])
     return Promise.resolve(loads[canonical]);
@@ -118,7 +118,7 @@ Trace.prototype.getLoadRecord = function(canonical) {
       .then(function() {
         // allow build: false trace opt-out
         if (metadata.build === false)
-          return null;
+          return false;
       
         // environment trace
         return loader.normalize(pkg.map['@env'] || '@system-env')
@@ -170,7 +170,7 @@ Trace.prototype.getLoadRecord = function(canonical) {
       .then(function(address) {
         // allow build: false trace opt-out
         if (metadata.build === false)
-          return null;
+          return false;
 
         // glob the conditional interpolation variations from the filesystem
         if (address.substr(0, 8) != 'file:///')
@@ -209,7 +209,7 @@ Trace.prototype.getLoadRecord = function(canonical) {
     .then(function(address) {
       // build: false build config - null load record
       if (load.metadata.build === false)
-        return null;
+        return false;
 
       // build: false plugins - runtime plugins
       if (load.metadata.loaderModule && load.metadata.loaderModule.build === false)
@@ -294,11 +294,11 @@ Trace.prototype.getAllLoadRecords = function(canonical, traceAllConditionals, co
   var self = this;
   return this.getLoadRecord(canonical)
   .then(function(load) {
-    // conditionals, build: false and system modules are null loads in the trace trees
+    // conditionals, build: false and system modules are false loads in the trace trees
     // (that is, part of depcache, but not built)
     // we skip system modules starting with @ though
     if (canonical[0] != '@')
-      curLoads[canonical] = load && load.conditional ? null : load;
+      curLoads[canonical] = load && load.conditional ? false : load;
 
     if (load)
       return Promise.all(Trace.getLoadDependencies(load, traceAllConditionals, conditionalEnv).map(function(dep) {
@@ -324,7 +324,7 @@ Trace.prototype.getConditionLoadRecords = function(canonical, inConditionTree, c
   return this.getLoadRecord(canonical)
   .then(function(load) {
     if (inConditionTree)
-      curLoads[canonical] = load && load.conditional ? null : load;
+      curLoads[canonical] = load && load.conditional ? false : load;
 
     if (load)
       return Promise.all(Trace.getLoadDependencies(load, true, {}).map(function(dep) {

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -364,13 +364,20 @@ Trace.prototype.getConditionLoadRecords = function(canonical, conditionalEnv, in
   var self = this;
   return this.getLoadRecord(canonical)
   .then(function(load) {
-    if (inConditionTree)
+    if (inConditionTree && canonical[0] != '@')
       curLoads[canonical] = load && load.conditional ? false : load;
 
     if (load)
-      return Promise.all(Trace.getLoadDependencies(load, true, conditionalEnv).map(function(dep) {
-        return self.getConditionLoadRecords(dep, inConditionTree || !!load.conditional, curLoads);
-      }));
+      // trace into the conditions themselves
+      return Promise.all(Trace.getLoadDependencies(load, true, conditionalEnv, true).map(function(dep) {
+        return self.getConditionLoadRecords(dep, conditionalEnv, true, curLoads);
+      }))
+      .then(function() {
+        // trace non-conditions
+        return Promise.all(Trace.getLoadDependencies(load, true, conditionalEnv).map(function(dep) {
+          return self.getConditionLoadRecords(dep, conditionalEnv, inConditionTree, curLoads);
+        }));
+      });
   })
   .then(function() {
     return curLoads;
@@ -378,8 +385,9 @@ Trace.prototype.getConditionLoadRecords = function(canonical, conditionalEnv, in
 }
 
 // Returns the ordered immediate dependency array from the trace of a module
-Trace.getLoadDependencies = function(load, traceAllConditionals, conditionalEnv) {
-  traceAllConditionals = traceAllConditionals || true;
+Trace.getLoadDependencies = function(load, traceAllConditionals, conditionalEnv, conditionsOnly) {
+  if (traceAllConditionals !== false)
+    traceAllConditionals = true;
   conditionalEnv = conditionalEnv || {};
 
   var deps = [];
@@ -387,14 +395,20 @@ Trace.getLoadDependencies = function(load, traceAllConditionals, conditionalEnv)
   function envTrace(condition) {
     // trace the condition modules as dependencies themselves
     var exportIndex = condition.lastIndexOf('|');
-    if (condition[0] == '~')
-      deps.push(condition.substr(1, exportIndex - 1));
-    else
-      deps.push(condition.substr(0, exportIndex));
+    if (exportIndex == -1) {
+      condition += '|default';
+      exportIndex = condition.length;
+    }
+
+    var negate = condition[0] == '~';
+    var conditionModule = condition.substr(negate, exportIndex - negate);
+    var conditionExport = (negate ? '~' : '') + condition.substr(exportIndex + 1);
+
+    deps.push(conditionModule);
 
     // return the environment trace info
-    var envTrace = conditionalEnv[condition];
-    return envTrace === undefined ? traceAllConditionals : envTrace;
+    var envTrace = conditionalEnv[conditionModule] && conditionalEnv[conditionModule][conditionExport];
+    return !conditionsOnly && (envTrace === undefined ? traceAllConditionals : envTrace);
   }
 
   // conditional load records have their branches all included in the trace
@@ -412,17 +426,17 @@ Trace.getLoadDependencies = function(load, traceAllConditionals, conditionalEnv)
         if (envTrace(env.condition))
           deps.push(env.branch);
       });
-      if (conditional.fallback)
+      if (conditional.fallback && !conditionsOnly)
         deps.push(conditional.fallback);
     }
 
     // { condition, branches } conditional interpolation
     else if (conditional.branches) {
       var et = envTrace(conditional.condition);
-      if (et) {
+      if (et !== undefined && et !== false) {
         Object.keys(conditional.branches).forEach(function(branch) {
           var dep = conditional.branches[branch];
-          if (et == true)
+          if (et === true)
             deps.push(dep);
           else if (et.indexOf(branch) != -1)
             deps.push(dep);
@@ -433,6 +447,9 @@ Trace.getLoadDependencies = function(load, traceAllConditionals, conditionalEnv)
     // run the conditional trace
     return deps;
   }
+
+  if (conditionsOnly)
+    return deps;
 
   // if this record uses a runtime plugin (build: false), trace the plugin
   if (load.runtimePlugin)

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -4,6 +4,8 @@ var toFileURL = require('./utils').toFileURL;
 var fromFileURL = require('./utils').fromFileURL;
 var asp = require('rsvp').denodeify;
 var fs = require('fs');
+var Graph = require('algorithms/data_structures/graph');
+var depthFirst = require('algorithms/graph').depthFirstSearch;
 
 module.exports = Trace;
 
@@ -399,4 +401,62 @@ Trace.getLoadDependencies = function(load, traceAllConditionals, conditionalEnv)
   return load.deps.map(function(dep) {
     return load.depMap[dep];
   });
+};
+
+function getGraphEntryPoints(graph, entryPoints) {
+  entryPoints = [].concat(entryPoints || []);
+
+  var modules = Object.keys(graph.adjList);
+  var discarded = {};
+
+  modules.forEach(function (moduleName) {
+    Object.keys(graph.adjList[moduleName]).forEach(function (depName) {
+      discarded[depName] = true;
+    });
+  });
+
+  modules.filter(function (moduleName) {
+    return !discarded[moduleName];
+  }).sort().forEach(function (moduleName) {
+    if (entryPoints.indexOf(moduleName) === -1) {
+      entryPoints.push(moduleName);
+    }
+  });
+
+  return entryPoints;
+}
+
+Trace.getTreeModulesPostOrder = function getTreeModulesPostOrder(tree, entryPoints) {
+  entryPoints = entryPoints || [];
+
+  // Post order traversal sorted module list
+  var postOrder = [];
+  var graph = new Graph(true);
+
+  // Seed graph with all relations
+  Object.keys(tree).forEach(function (moduleName) {
+    var load = tree[moduleName];
+
+    if (!graph.adjList[moduleName]) {
+      graph.addVertex(moduleName);
+    }
+
+    Trace.getLoadDependencies(load).forEach(function (depName) {
+      graph.addEdge(moduleName, depName);
+    });
+  });
+
+  // Post order traversal of graph, one per entryPoint
+  getGraphEntryPoints(graph, entryPoints).forEach(function (entryPoint) {
+    depthFirst(graph, entryPoint, {
+      leaveVertex: function (moduleName) {
+        // Avoid duplicates and modules that have been skipped by tracer
+        if (postOrder.indexOf(moduleName) === -1 && moduleName in tree) {
+          postOrder.push(moduleName);
+        }
+      }
+    });
+  });
+
+  return postOrder;
 };

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -6,17 +6,57 @@ var asp = require('rsvp').denodeify;
 var fs = require('fs');
 var Graph = require('algorithms/data_structures/graph');
 var depthFirst = require('algorithms/graph').depthFirstSearch;
+var path = require('path');
 
 module.exports = Trace;
 
 function Trace(loader, traceCache) {
   this.loader = loader;
   // stored traced load records
-  this.loads = traceCache;
+  this.loads = traceCache || {};
   // in progress traces
   this.tracing = {};
 }
 
+/*
+ * High-level functions
+ */
+var namedRegisterRegEx = /(System\.register(Dynamic)?|define)\(('[^']+'|"[^"]+")/g;
+Trace.prototype.traceModule = function(moduleName, traceAllConditionals, conditionalEnv, conditionsOnly) {
+  var loader = this.loader;
+
+  var self = this;
+  
+  return Promise.resolve(loader.normalize(moduleName))
+  .then(function(_moduleName) {
+    moduleName = getCanonicalName(loader, _moduleName);
+    if (!conditionsOnly)
+      return self.getAllLoadRecords(moduleName, traceAllConditionals, conditionalEnv);
+    else
+      return self.getConditionLoadRecords(moduleName, conditionalEnv);
+  })
+  .then(function(loads) {
+    // if it is a bundle, we just use a regex to extract the list of loads
+    // as "true" records for subtraction arithmetic use only
+    var thisLoad = loads[moduleName];
+
+    if (thisLoad && thisLoad.metadata.bundle) {
+      namedRegisterRegEx.lastIndex = 0;
+      var curMatch;
+      while ((curMatch = namedRegisterRegEx.exec(thisLoad.source)))
+        loads[curMatch[3].substr(1, curMatch[3].length - 2)] = true;
+    }
+
+    return {
+      moduleName: moduleName,
+      tree: loads
+    };
+  });
+};
+
+/*
+ * Low-level functions
+ */
 // runs the pipeline hooks, returning the load record for a module
 Trace.prototype.getLoadRecord = function(canonical) {
   var loader = this.loader;
@@ -39,8 +79,8 @@ Trace.prototype.getLoadRecord = function(canonical) {
 
     var load = {
       name: canonical,
-      normalized: normalized,
-      address: null,
+      // baseURL-relative path to address
+      path: null,
       metadata: null,
       deps: null,
       depMap: null,
@@ -219,15 +259,16 @@ Trace.prototype.getLoadRecord = function(canonical) {
           return load;
         });
 
-      load.address = address;
-      return Promise.resolve(loader.fetch({ name: normalized, metadata: load.metadata, address: load.address }))
+      load.path = path.relative(fromFileURL(loader.baseURL), fromFileURL(address));
+
+      return Promise.resolve(loader.fetch({ name: normalized, metadata: load.metadata, address: address }))
       .then(function(source) {
         load.originalSource = source;
-        return loader.translate({ name: normalized, metadata: load.metadata, address: load.address, source: source });
+        return loader.translate({ name: normalized, metadata: load.metadata, address: address, source: source });
       })
       .then(function(source) {
         load.source = source;
-        return loader.instantiate({ name: normalized, metadata: load.metadata, address: load.address, source: source });
+        return loader.instantiate({ name: normalized, metadata: load.metadata, address: address, source: source });
       })
       .then(function(result) {
         if (!result)
@@ -238,7 +279,7 @@ Trace.prototype.getLoadRecord = function(canonical) {
         // normalize dependencies to populate depMap
         load.depMap = {};
         return Promise.all(result.deps.map(function(dep) {
-          return loader.normalize(dep, normalized, load.address)
+          return loader.normalize(dep, normalized, address)
           .then(function(normalized) {
             load.depMap[dep] = getCanonicalName(loader, normalized);
           });
@@ -312,7 +353,7 @@ Trace.prototype.getAllLoadRecords = function(canonical, traceAllConditionals, co
 
 // helper function -> returns the "condition" build of a tree
 // that is the modules needed to determine the exact conditional solution of the tree
-Trace.prototype.getConditionLoadRecords = function(canonical, inConditionTree, curLoads) {
+Trace.prototype.getConditionLoadRecords = function(canonical, conditionalEnv, inConditionTree, curLoads) {
   var loader = this.loader;
 
   curLoads = curLoads || {};
@@ -327,7 +368,7 @@ Trace.prototype.getConditionLoadRecords = function(canonical, inConditionTree, c
       curLoads[canonical] = load && load.conditional ? false : load;
 
     if (load)
-      return Promise.all(Trace.getLoadDependencies(load, true, {}).map(function(dep) {
+      return Promise.all(Trace.getLoadDependencies(load, true, conditionalEnv).map(function(dep) {
         return self.getConditionLoadRecords(dep, inConditionTree || !!load.conditional, curLoads);
       }));
   })

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -1,4 +1,9 @@
 var getCanonicalName = require('./utils').getCanonicalName;
+var glob = require('glob');
+var toFileURL = require('./utils').toFileURL;
+var fromFileURL = require('./utils').fromFileURL;
+var asp = require('rsvp').denodeify;
+var fs = require('fs');
 
 module.exports = Trace;
 
@@ -11,40 +16,208 @@ function Trace(loader, traceCache) {
 }
 
 // runs the pipeline hooks, returning the load record for a module
-Trace.prototype.getLoadRecord = function(name) {
+Trace.prototype.getLoadRecord = function(canonical) {
   var loader = this.loader;
   var loads = this.loads;
 
+  // modules starting with "@" are assumed system modules
+  if (canonical.substr(0, 1) == '@')
+    return Promise.resolve(null);
+
+  if (loads[canonical])
+    return Promise.resolve(loads[canonical]);
+
+  if (this.tracing[canonical])
+    return self.tracing[canonical];
+
   var self = this;
 
-  return Promise.resolve(loader.normalize(name))
+  return this.tracing[canonical] = Promise.resolve(loader.normalize(canonical))
   .then(function(normalized) {
-    name = getCanonicalName(loader, normalized);
-
-    if (loads[name])
-      return Promise.resolve(loads[name]);
-
-    if (self.tracing[name])
-      return self.tracing[name];
 
     var load = {
-      name: name,
+      name: canonical,
       normalized: normalized,
       address: null,
-      metadata: {},
+      metadata: null,
       deps: null,
-      depMap: {},
+      depMap: null,
       source: null,
-      originalSource: null
-    };
+      originalSource: null,
 
-    // loader hooks
-    return (self.tracing[name] = Promise.resolve(loader.locate({ name: normalized, metadata: load.metadata}))
-    .then(function(address) {
-      load.address = address;
-      if (load.metadata.build === false || load.metadata.loaderModule && load.metadata.loaderModule.build === false)
-        return null;
+      // represents a build: false plugin that will not be built out for production
+      runtimePlugin: null,
       
+      // represents a conditional load record (sourceless)
+      conditional: null
+    };
+    
+    // -- conditional load record creation: sourceless intermediate load record --
+
+    // boolean conditional
+    var booleanIndex = canonical.lastIndexOf('#?');
+    if (booleanIndex != -1) {
+      var condition = canonical.substr(booleanIndex + 2)
+      if (condition.indexOf('|') == -1)
+        condition += '|default';
+      load.conditional = {
+        condition: condition,
+        branch: canonical.substr(0, booleanIndex)
+      };
+      return load;
+    }
+
+    // package environment conditional
+    var pkgEnvIndex = canonical.indexOf('#:');
+    if (pkgEnvIndex != -1) {
+      // NB handle a package plugin load here too
+      if (canonical.indexOf('!') != -1)
+        throw new Error('Unable to trace ' + canonical + ' - building package environment mappings of plugins is not currently supported.');
+
+      var pkgName = canonical.substr(0, pkgEnvIndex);
+      var subPath = canonical.substr(pkgEnvIndex + 2);
+
+      var normalizedPkgName = loader.normalizeSync(pkgName + '/');
+      normalizedPkgName = normalizedPkgName.substr(0, normalizedPkgName.length - 1);
+
+      var pkg = loader.packages[normalizedPkgName];
+      var envMap = pkg.map['./' + subPath];
+
+      // effective analog of the same function in SystemJS packages.js
+      // to work out the path with defaultExtension added.
+      // we cheat here and use normalizeSync to apply the right checks, while 
+      // skipping any map entry by temporarily removing it.
+      function toPackagePath(subPath) {
+        var pkgMap = pkg.map;
+        pkg.map = {};
+        var normalized = loader.normalizeSync(pkgName + '/' + subPath);
+        pkg.map = pkgMap;
+        return normalized;
+      }
+
+      var metadata = {};
+      var fallback;
+      return loader.locate({ name: toPackagePath(subPath), metadata: metadata })
+      .then(function(address) {
+        if (metadata.build === false)
+          return;
+
+        fallback = getCanonicalName(loader, address);
+
+        // check if the fallback exists
+        return new Promise(function(resolve) {
+          fs.exists(fromFileURL(address), resolve);
+        })
+        .then(function(fallbackExists) {
+          if (!fallbackExists)
+            fallback = null;
+        });
+      })
+      .then(function() {
+        // allow build: false trace opt-out
+        if (metadata.build === false)
+          return null;
+      
+        // environment trace
+        return loader.normalize(pkg.map['@env'] || '@system-env')
+        .then(function(normalizedCondition) {
+          var conditionModule = getCanonicalName(loader, normalizedCondition);
+
+          return Promise.all(Object.keys(envMap).map(function(envCondition) {
+            var mapping = envMap[envCondition];
+            var negate = envCondition[0] == '~';
+
+            return Promise.resolve()
+            .then(function() {
+              if (mapping == '.')
+                return normalizedPkgName;
+              else if (mapping.substr(0, 2) == './')
+                return toPackagePath(mapping.substr(2))
+              else
+                return loader.normalize(mapping);
+            })
+            .then(function(normalizedMapping) {
+              return {
+                condition: (negate ? '~' : '') + conditionModule + '|' + (negate ? envCondition.substr(1) : envCondition),
+                branch: getCanonicalName(loader, normalizedMapping)
+              };
+            });
+          }));
+        })
+        .then(function(envs) {
+          load.conditional = {
+            envs: envs,
+            fallback: fallback
+          };
+          return load;
+        });
+      });
+    }
+
+    // conditional interpolation
+    var interpolationRegEx = /#\{[^\}]+\}/;
+    var interpolationMatch = canonical.match(interpolationRegEx);
+    if (interpolationMatch) {
+      var condition = interpolationMatch[0].substr(2, interpolationMatch[0].length - 3);
+
+      if (condition.indexOf('|') == -1)
+        condition += '|default';
+
+      var metadata = {};
+      return Promise.resolve(loader.locate({ name: normalized.replace(interpolationRegEx, '*'), metadata: metadata }))
+      .then(function(address) {
+        // allow build: false trace opt-out
+        if (metadata.build === false)
+          return null;
+
+        // glob the conditional interpolation variations from the filesystem
+        if (address.substr(0, 8) != 'file:///')
+          throw new Error('Error tracing ' + canonical + '. It is only possible to trace conditional interpolation for modules resolving to local file:/// URLs during the build.');
+
+        var globIndex = address.indexOf('*');
+        return asp(glob)(fromFileURL(address), { dot: true, nobrace: true, noglobstar: true, noext: true, nodir: true })
+        .then(function(paths) {
+          var branches = {};
+          paths.forEach(function(path) {
+            path = toFileURL(path);
+
+            var pathCanonical = getCanonicalName(loader, path);
+            var interpolate = pathCanonical.substr(interpolationMatch.index, path.length - address.length + 1);
+
+            if (metadata.plugin) {
+              if (loader.pluginFirst)
+                pathCanonical = metadata.plugin + '!' + pathCanonical;
+              else
+                pathCanonical = pathCanonical + '!' + metadata.plugin;
+            }
+            branches[interpolate] = pathCanonical;
+          });
+
+          load.conditional = {
+            condition: condition,
+            branches: branches
+          };
+          return load;
+        });
+      });
+    }
+
+    // -- trace loader hooks --
+    return Promise.resolve(loader.locate({ name: normalized, metadata: load.metadata = {}}))
+    .then(function(address) {
+      // build: false build config - null load record
+      if (load.metadata.build === false)
+        return null;
+
+      // build: false plugins - runtime plugins
+      if (load.metadata.loaderModule && load.metadata.loaderModule.build === false)
+        return Promise.resolve(loader.normalize(load.metadata.loader, normalized))
+        .then(function(pluginNormalized) {
+          load.runtimePlugin = getCanonicalName(loader, pluginNormalized);
+          return load;
+        });
+
+      load.address = address;
       return Promise.resolve(loader.fetch({ name: normalized, metadata: load.metadata, address: load.address }))
       .then(function(source) {
         load.originalSource = source;
@@ -57,14 +230,11 @@ Trace.prototype.getLoadRecord = function(name) {
       .then(function(result) {
         if (!result)
           throw new TypeError('Native ES Module builds not supported. Ensure transpilation is included in the loader pipeline.');
-        
-        // make address sourceMap-friendly
-        if (load.address.indexOf('!') != -1)
-          load.address = load.address.substr(0, load.address.indexOf('!'));
 
         load.deps = result.deps;
 
         // normalize dependencies to populate depMap
+        load.depMap = {};
         return Promise.all(result.deps.map(function(dep) {
           return loader.normalize(dep, normalized, load.address)
           .then(function(normalized) {
@@ -78,56 +248,150 @@ Trace.prototype.getLoadRecord = function(name) {
         delete load.metadata.builderExecute;
         delete load.metadata.parseTree;
 
-        return loads[name] = load;
+        return load;
       });
-    }));
+    });
+  })
+  .then(function(load) {
+    return loads[canonical] = load;
   });
 };
 
-// traces a load and all its dependencies, returning the tree object
-Trace.prototype.getAllLoadRecords = function(name, curLoads) {
+/*
+ * Returns the full trace tree of a module
+ * 
+ * - traceAllConditionals indicates if conditional boundaries should be traversed during the trace.
+ * - conditionalEnv represents the conditional tracing environment module values to impose on the trace
+ *   forcing traces for traceAllConditionals false, and skipping traces for traceAllConditionals true.
+ * 
+ * conditionalEnv provides canonical condition tracing rules of the form:
+ * 
+ *  {
+ *    'some/interpolation|value': true, // include ALL variations
+ *    'another/interpolation|value': false, // include NONE
+ *    'custom/interpolation|value': ['specific', 'values']
+ *
+ *    // default BOOLEAN entry::
+ *    '@system-env|browser': false,
+ *    '~@system-env|browser': false
+ *
+ *    // custom boolean entry
+ *    // boolean only checks weak truthiness to allow overlaps
+ *    '~@system-env|node': true
+ *  }
+ *
+ */
+Trace.prototype.getAllLoadRecords = function(canonical, traceAllConditionals, conditionalEnv, curLoads) {
   var loader = this.loader;
 
   curLoads = curLoads || {};
 
-  if (name == '@empty')
+  if (canonical in curLoads)
     return curLoads;
 
   var self = this;
+  return this.getLoadRecord(canonical)
+  .then(function(load) {
+    // conditionals, build: false and system modules are null loads in the trace trees
+    // (that is, part of depcache, but not built)
+    curLoads[canonical] = load && load.conditional ? null : load;
 
-  return Promise.resolve(loader.normalize(name))
-  .then(function(normalized) {
-    name = getCanonicalName(loader, normalized);
-
-    if (curLoads[name])
-      return curLoads;
-
-    return self.getLoadRecord(normalized)
-    .then(function(load) {
-      // build: false will return a null
-      if (load == null)
-        return curLoads;
-
-      curLoads[name] = load;
-
-      return Promise.resolve()
-      .then(function() {
-        // if this record uses a plugin, trace the plugin as well
-        if (load.metadata.loader && load.metadata.build === false)
-          return Promise.resolve(self.loader.normalize(load.metadata.loader, name))
-          .then(function(pluginName) {
-            return self.getAllLoadRecords(pluginName, curLoads);
-          });
-      })
-      .then(function() {
-        return Promise.all(load.deps.map(function(dep) {
-          return self.getAllLoadRecords(load.depMap[dep], curLoads);
-        }));
-      })
-      .then(function() {
-        return curLoads;
-      });
-    });
+    if (load)
+      return Promise.all(self.getLoadDependencies(load, traceAllConditionals, conditionalEnv).map(function(dep) {
+        return self.getAllLoadRecords(dep, traceAllConditionals, conditionalEnv, curLoads);
+      }));
+  })
+  .then(function() {
+    return curLoads;
   });
 };
 
+// helper function -> returns the "condition" build of a tree
+// that is the modules needed to determine the exact conditional solution of the tree
+Trace.prototype.getConditionLoadRecords = function(canonical, inConditionTree, curLoads) {
+  var loader = this.loader;
+
+  curLoads = curLoads || {};
+
+  if (canonical in curLoads)
+    return curLoads;
+
+  var self = this;
+  return this.getLoadRecord(canonical)
+  .then(function(load) {
+    if (inConditionTree)
+      curLoads[canonical] = load && load.conditional ? null : load;
+
+    if (load)
+      return Promise.all(self.getLoadDependencies(load, true, {}).map(function(dep) {
+        return self.getConditionLoadRecords(dep, inConditionTree || !!load.conditional, curLoads);
+      }));
+  })
+  .then(function() {
+    return curLoads;
+  });
+}
+
+// Returns the ordered immediate dependency array from the trace of a module
+Trace.prototype.getLoadDependencies = function(load, traceAllConditionals, conditionalEnv) {
+  var deps = [];
+
+  function envTrace(condition) {
+    // trace the condition modules as dependencies themselves
+    var exportIndex = condition.lastIndexOf('|');
+    if (condition[0] == '~')
+      deps.push(condition.substr(1, exportIndex - 1));
+    else
+      deps.push(condition.substr(0, exportIndex));
+
+    // return the environment trace info
+    var envTrace = conditionalEnv[condition];
+    return envTrace === undefined ? traceAllConditionals : envTrace;
+  }
+
+  // conditional load records have their branches all included in the trace
+  var conditional = load.conditional;
+  if (conditional) {
+    // { condition, branch } boolean conditional
+    if (conditional.branch) {
+      if (envTrace(conditional.condition))
+        deps.push(branch);
+    }
+
+    // { envs: [{condition, branch},...], fallback } package environment map
+    else if (conditional.envs) {
+      conditional.envs.forEach(function(env) {
+        if (envTrace(env.condition))
+          deps.push(env.branch);
+      });
+      if (conditional.fallback)
+        deps.push(conditional.fallback);
+    }
+
+    // { condition, branches } conditional interpolation
+    else if (conditional.branches) {
+      var et = envTrace(conditional.condition);
+      if (et) {
+        Object.keys(conditional.branches).forEach(function(branch) {
+          var dep = conditional.branches[branch];
+          if (et == true)
+            deps.push(dep);
+          else if (et.indexOf(branch) != -1)
+            deps.push(dep);
+        });
+      }
+    }
+
+    // run the conditional trace
+    return deps;
+  }
+
+  // if this record uses a runtime plugin (build: false), trace the plugin
+  if (load.runtimePlugin)
+    return [load.runtimePlugin];
+
+  // standard dep trace
+  return load.deps.map(function(dep) {
+    return load.depMap[dep];
+  });
+};

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -7,6 +7,7 @@ var fs = require('fs');
 var Graph = require('algorithms/data_structures/graph');
 var depthFirst = require('algorithms/graph').depthFirstSearch;
 var path = require('path');
+var extend = require('./utils').extend;
 
 module.exports = Trace;
 
@@ -76,24 +77,6 @@ Trace.prototype.getLoadRecord = function(canonical) {
 
   return this.tracing[canonical] = Promise.resolve(loader.normalize(canonical))
   .then(function(normalized) {
-
-    var load = {
-      name: canonical,
-      // baseURL-relative path to address
-      path: null,
-      metadata: null,
-      deps: null,
-      depMap: null,
-      source: null,
-      originalSource: null,
-
-      // represents a build: false plugin that will not be built out for production
-      runtimePlugin: null,
-      
-      // represents a conditional load record (sourceless)
-      conditional: null
-    };
-    
     // -- conditional load record creation: sourceless intermediate load record --
 
     // boolean conditional
@@ -102,11 +85,13 @@ Trace.prototype.getLoadRecord = function(canonical) {
       var condition = canonical.substr(booleanIndex + 2)
       if (condition.indexOf('|') == -1)
         condition += '|default';
-      load.conditional = {
-        condition: condition,
-        branch: canonical.substr(0, booleanIndex)
+      return {
+        name: canonical,
+        conditional: {
+          condition: condition,
+          branch: canonical.substr(0, booleanIndex)
+        }
       };
-      return load;
     }
 
     // package environment conditional
@@ -141,8 +126,9 @@ Trace.prototype.getLoadRecord = function(canonical) {
       var fallback;
       return loader.locate({ name: toPackagePath(subPath), metadata: metadata })
       .then(function(address) {
+        // allow build: false trace opt-out
         if (metadata.build === false)
-          return;
+          return false;
 
         fallback = getCanonicalName(loader, address);
 
@@ -156,10 +142,6 @@ Trace.prototype.getLoadRecord = function(canonical) {
         });
       })
       .then(function() {
-        // allow build: false trace opt-out
-        if (metadata.build === false)
-          return false;
-      
         // environment trace
         return loader.normalize(pkg.map['@env'] || '@system-env')
         .then(function(normalizedCondition) {
@@ -187,11 +169,13 @@ Trace.prototype.getLoadRecord = function(canonical) {
           }));
         })
         .then(function(envs) {
-          load.conditional = {
-            envs: envs,
-            fallback: fallback
+          return {
+            name: canonical,
+            conditional: {
+              envs: envs,
+              fallback: fallback
+            }
           };
-          return load;
         });
       });
     }
@@ -235,16 +219,31 @@ Trace.prototype.getLoadRecord = function(canonical) {
             branches[interpolate] = pathCanonical;
           });
 
-          load.conditional = {
-            condition: condition,
-            branches: branches
+          return {
+            name: canonical,
+            conditional: {
+              condition: condition,
+              branches: branches
+            }
           };
-          return load;
         });
       });
     } 
 
     // -- trace loader hooks --
+    var load = {
+      name: canonical,
+      // baseURL-relative path to address
+      path: null,
+      metadata: null,
+      deps: null,
+      depMap: null,
+      source: null,
+      originalSource: null,
+
+      // represents a build: false plugin that will not be built out for production
+      runtimePlugin: null
+    };
     var curHook = 'locate';
     return Promise.resolve(loader.locate({ name: normalized, metadata: load.metadata = {}}))
     .then(function(address) {
@@ -362,11 +361,11 @@ Trace.prototype.getAllLoadRecords = function(canonical, traceAllConditionals, co
   var self = this;
   return this.getLoadRecord(canonical)
   .then(function(load) {
-    // conditionals, build: false and system modules are false loads in the trace trees
+    // conditionals, build: false and system modules are falsy loads in the trace trees
     // (that is, part of depcache, but not built)
     // we skip system modules starting with @ though
     if (canonical[0] != '@')
-      curLoads[canonical] = load && load.conditional ? false : load;
+      curLoads[canonical] = load && load.conditional ? null : load;
 
     if (load)
       return Promise.all(Trace.getLoadDependencies(load, traceAllConditionals, conditionalEnv).map(function(dep) {
@@ -392,7 +391,7 @@ Trace.prototype.getConditionLoadRecords = function(canonical, conditionalEnv, in
   return this.getLoadRecord(canonical)
   .then(function(load) {
     if (inConditionTree && canonical[0] != '@')
-      curLoads[canonical] = load && load.conditional ? false : load;
+      curLoads[canonical] = load && load.conditional ? null : load;
 
     if (load)
       // trace into the conditions themselves
@@ -411,13 +410,90 @@ Trace.prototype.getConditionLoadRecords = function(canonical, conditionalEnv, in
   });
 }
 
-// Returns the ordered immediate dependency array from the trace of a module
-Trace.getLoadDependencies = function(load, traceAllConditionals, conditionalEnv, conditionsOnly) {
+/*
+ * to support static conditional builds, we use the conditional tracing options
+ * to inline resolved conditions for the trace
+ * basically rewriting the tree without any conditionals
+ * where conditions are still present or conflicting we throw an error
+ */
+Trace.prototype.inlineConditions = function(tree, conditionalEnv) {
+  var inconsistencyErrorMsg = 'For static condition inlining only an exact environment resolution can be built, pending https://github.com/systemjs/builder/issues/311.';
+  
+  // ensure we have no condition conflicts
+  for (var c in conditionalEnv) {
+    var val = conditionalEnv[c];
+    if (typeof val == 'string')
+      continue;
+    var negated = false;
+    if (c[0] == '~')
+      negated = true;
+    var complement = negated && c.substr(1) || !negated && '~' + c;
+    if (val instanceof Array || complement in conditionalEnv && conditionalEnv[complement] != !conditionalEnv[c])
+      throw new TypeError('Error building condition ' + c + '. ' + inconsistencyErrorMsg);
+  }
+
+  var conditionals = {};
+  var conditionalResolutions = {};
+
+  var self = this;
+
+  // populate all null conditionals that were stripped from the tree
+  return Promise.all(Object.keys(tree).filter(function(m) {
+    return tree[m] === null;
+  }).map(function(m) {
+    return self.getLoadRecord(m)
+    .then(function(load) {
+      conditionals[m] = load;
+    });
+  }))
+  .then(function() {
+    // for each conditional, work out its substitution
+    Object.keys(conditionals).forEach(function(c) {
+      var resolution = Trace.getConditionalResolutions(conditionals[c].conditional, false, conditionalEnv);
+      var branches = resolution.branches;
+      if (branches.length > 1)
+        throw new TypeError('Error building condition ' + c + '. ' + inconsistencyErrorMsg);
+      if (branches.length == 0)
+        throw new TypeError('No resolution found at all for condition ' + c + '.');
+
+      conditionalResolutions[c] = branches[0];
+    });
+
+    // finally we do a deep clone of the tree, applying the conditional resolutions as we go
+    var inlinedTree = {};
+    Object.keys(tree).forEach(function(m) {
+      var load = tree[m];
+
+      if (typeof load == 'boolean') {
+        inlinedTree[m] = load;
+        return;
+      }
+
+      if (load === null)
+        return;
+
+      var clonedLoad = extend({}, load);
+      clonedLoad.depMap = {};
+      Object.keys(load.depMap).forEach(function(d) {
+        var normalizedDep = load.depMap[d];
+        clonedLoad.depMap[d] = conditionalResolutions[normalizedDep] || normalizedDep;
+      });
+
+      inlinedTree[m] = clonedLoad;
+    });
+
+    return inlinedTree;
+  });
+};
+
+Trace.getConditionalResolutions = function(conditional, traceAllConditionals, conditionalEnv) {
   if (traceAllConditionals !== false)
     traceAllConditionals = true;
   conditionalEnv = conditionalEnv || {};
 
-  var deps = [];
+  // flattens all condition objects into a resolution object
+  // with the condition module and possible branches given the environment segment
+  var resolution = { condition: null, branches: [] };
 
   function envTrace(condition) {
     // trace the condition modules as dependencies themselves
@@ -431,52 +507,67 @@ Trace.getLoadDependencies = function(load, traceAllConditionals, conditionalEnv,
     var conditionModule = condition.substr(negate, exportIndex - negate) || '@system-env';
     var conditionExport = (negate ? '~' : '') + condition.substr(exportIndex + 1);
 
-    deps.push(conditionModule);
+    resolution.condition = conditionModule;
 
     // return the environment trace info
     var envTrace = conditionalEnv[conditionModule] && conditionalEnv[conditionModule][conditionExport];
-    return !conditionsOnly && (envTrace === undefined ? traceAllConditionals : envTrace);
+    return envTrace === undefined ? traceAllConditionals : envTrace;
   }
+
+  var deps = [];
+
+  // { condition, branch } boolean conditional
+  if (conditional.branch) {
+    if (envTrace(conditional.condition))
+      resolution.branches.push(conditional.branch);
+    else
+      resolution.branches.push('@empty');
+  }
+
+  // { envs: [{condition, branch},...], fallback } package environment map
+  else if (conditional.envs) {
+    conditional.envs.forEach(function(env) {
+      if (envTrace(env.condition))
+        resolution.branches.push(env.branch);
+    });
+    if (conditional.fallback)
+      resolution.branches.push(conditional.fallback);
+  }
+
+  // { condition, branches } conditional interpolation
+  else if (conditional.branches) {
+    var et = envTrace(conditional.condition);
+    if (et !== undefined && et !== false) {
+      Object.keys(conditional.branches).forEach(function(branch) {
+        var dep = conditional.branches[branch];
+        if (et === true)
+          resolution.branches.push(dep);
+        else if (et.indexOf(branch) != -1)
+          resolution.branches.push(dep);
+      });
+    }
+  }
+
+  return resolution;
+};
+
+// Returns the ordered immediate dependency array from the trace of a module
+Trace.getLoadDependencies = function(load, traceAllConditionals, conditionalEnv, conditionsOnly) {
+  if (traceAllConditionals !== false)
+    traceAllConditionals = true;
+  conditionalEnv = conditionalEnv || {};
+
+  if (!load.conditional && conditionsOnly)
+    return [];
 
   // conditional load records have their branches all included in the trace
-  var conditional = load.conditional;
-  if (conditional) {
-    // { condition, branch } boolean conditional
-    if (conditional.branch) {
-      if (envTrace(conditional.condition))
-        deps.push(conditional.branch);
-    }
-
-    // { envs: [{condition, branch},...], fallback } package environment map
-    else if (conditional.envs) {
-      conditional.envs.forEach(function(env) {
-        if (envTrace(env.condition))
-          deps.push(env.branch);
-      });
-      if (conditional.fallback && !conditionsOnly)
-        deps.push(conditional.fallback);
-    }
-
-    // { condition, branches } conditional interpolation
-    else if (conditional.branches) {
-      var et = envTrace(conditional.condition);
-      if (et !== undefined && et !== false) {
-        Object.keys(conditional.branches).forEach(function(branch) {
-          var dep = conditional.branches[branch];
-          if (et === true)
-            deps.push(dep);
-          else if (et.indexOf(branch) != -1)
-            deps.push(dep);
-        });
-      }
-    }
-
-    // run the conditional trace
-    return deps;
+  if (load.conditional) {
+    var resolution = Trace.getConditionalResolutions(load.conditional, traceAllConditionals, conditionalEnv);
+    if (conditionsOnly)
+      return [resolution.condition];
+    else
+      return [resolution.condition].concat(resolution.branches);
   }
-
-  if (conditionsOnly)
-    return deps;
 
   // if this record uses a runtime plugin (build: false), trace the plugin
   if (load.runtimePlugin)

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -598,13 +598,10 @@ function getGraphEntryPoints(graph, entryPoints) {
       entryPoints.push(moduleName);
     }
   });
-
   return entryPoints;
 }
 
 Trace.getTreeModulesPostOrder = function getTreeModulesPostOrder(tree, entryPoints) {
-  entryPoints = entryPoints || [];
-
   // Post order traversal sorted module list
   var postOrder = [];
   var graph = new Graph(true);
@@ -626,7 +623,8 @@ Trace.getTreeModulesPostOrder = function getTreeModulesPostOrder(tree, entryPoin
   });
 
   // Post order traversal of graph, one per entryPoint
-  getGraphEntryPoints(graph, entryPoints).forEach(function (entryPoint) {
+  entryPoints = getGraphEntryPoints(graph, entryPoints);
+  entryPoints.forEach(function (entryPoint) {
     depthFirst(graph, entryPoint, {
       leaveVertex: function (moduleName) {
         // Avoid duplicates and modules that have been skipped by tracer
@@ -637,5 +635,8 @@ Trace.getTreeModulesPostOrder = function getTreeModulesPostOrder(tree, entryPoin
     });
   });
 
-  return postOrder;
+  return {
+    modules: postOrder,
+    entryPoints: entryPoints
+  };
 };

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -299,7 +299,7 @@ Trace.prototype.getAllLoadRecords = function(canonical, traceAllConditionals, co
       curLoads[canonical] = load && load.conditional ? null : load;
 
     if (load)
-      return Promise.all(self.getLoadDependencies(load, traceAllConditionals, conditionalEnv).map(function(dep) {
+      return Promise.all(Trace.getLoadDependencies(load, traceAllConditionals, conditionalEnv).map(function(dep) {
         return self.getAllLoadRecords(dep, traceAllConditionals, conditionalEnv, curLoads);
       }));
   })
@@ -325,7 +325,7 @@ Trace.prototype.getConditionLoadRecords = function(canonical, inConditionTree, c
       curLoads[canonical] = load && load.conditional ? null : load;
 
     if (load)
-      return Promise.all(self.getLoadDependencies(load, true, {}).map(function(dep) {
+      return Promise.all(Trace.getLoadDependencies(load, true, {}).map(function(dep) {
         return self.getConditionLoadRecords(dep, inConditionTree || !!load.conditional, curLoads);
       }));
   })
@@ -335,7 +335,10 @@ Trace.prototype.getConditionLoadRecords = function(canonical, inConditionTree, c
 }
 
 // Returns the ordered immediate dependency array from the trace of a module
-Trace.prototype.getLoadDependencies = function(load, traceAllConditionals, conditionalEnv) {
+Trace.getLoadDependencies = function(load, traceAllConditionals, conditionalEnv) {
+  traceAllConditionals = traceAllConditionals || true;
+  conditionalEnv = conditionalEnv || {};
+
   var deps = [];
 
   function envTrace(condition) {

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -428,7 +428,7 @@ Trace.getLoadDependencies = function(load, traceAllConditionals, conditionalEnv,
     }
 
     var negate = condition[0] == '~';
-    var conditionModule = condition.substr(negate, exportIndex - negate);
+    var conditionModule = condition.substr(negate, exportIndex - negate) || '@system-env';
     var conditionExport = (negate ? '~' : '') + condition.substr(exportIndex + 1);
 
     deps.push(conditionModule);
@@ -444,7 +444,7 @@ Trace.getLoadDependencies = function(load, traceAllConditionals, conditionalEnv,
     // { condition, branch } boolean conditional
     if (conditional.branch) {
       if (envTrace(conditional.condition))
-        deps.push(branch);
+        deps.push(conditional.branch);
     }
 
     // { envs: [{condition, branch},...], fallback } package environment map

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -437,6 +437,9 @@ Trace.getTreeModulesPostOrder = function getTreeModulesPostOrder(tree, entryPoin
   Object.keys(tree).forEach(function (moduleName) {
     var load = tree[moduleName];
 
+    if (!load)
+      return;
+
     if (!graph.adjList[moduleName]) {
       graph.addVertex(moduleName);
     }

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -28,7 +28,7 @@ Trace.prototype.getLoadRecord = function(canonical) {
     return Promise.resolve(loads[canonical]);
 
   if (this.tracing[canonical])
-    return self.tracing[canonical];
+    return this.tracing[canonical];
 
   var self = this;
 
@@ -294,7 +294,9 @@ Trace.prototype.getAllLoadRecords = function(canonical, traceAllConditionals, co
   .then(function(load) {
     // conditionals, build: false and system modules are null loads in the trace trees
     // (that is, part of depcache, but not built)
-    curLoads[canonical] = load && load.conditional ? null : load;
+    // we skip system modules starting with @ though
+    if (canonical[0] != '@')
+      curLoads[canonical] = load && load.conditional ? null : load;
 
     if (load)
       return Promise.all(self.getLoadDependencies(load, traceAllConditionals, conditionalEnv).map(function(dep) {

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -296,7 +296,7 @@ Trace.prototype.getLoadRecord = function(canonical) {
         if (!curHook)
           return;
 
-        var msg = 'Error running ' + curHook + ' hook for ' + canonical + ' at ' + normalized;
+        var msg = 'Error on ' + curHook + ' for ' + canonical + ' at ' + normalized;
 
         // rethrow loader hook errors with the hook information
         var newErr;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,49 +8,89 @@ function extend(a, b) {
   return a;
 }
 
-function fromFileURL(url) {
-  return url.substr(7 + !!process.platform.match(/^win/)).replace(/\//g, path.sep);
-}
+var isWin = process.platform.match(/^win/);
+
 exports.fromFileURL = fromFileURL;
-
-function toFileURL(path) {
-  return 'file://' + (process.platform.match(/^win/) ? '/' : '') + path.replace(/\\/g, '/');
+function fromFileURL(url) {
+  return url.substr(7 + !!isWin).replace(/\//g, path.sep);
 }
+
 exports.toFileURL = toFileURL;
-
-function isFileURL(url) {
-  return url.substr(0, 5) === 'file:';
+function toFileURL(path) {
+  return 'file://' + (isWin ? '/' : '') + path.replace(/\\/g, '/');
 }
-exports.isFileURL = isFileURL;
 
-/* Remove scheme prefix from file URLs, so that they are paths. */
-function filePath(url) {
-  if (isFileURL(url))
-    return url.replace(/^file:\/+/, '/');
+exports.getAlias = getAlias
+function getAlias(loader, canonicalName) {
+  var bestAlias;
+
+  function getBestAlias(mapped) {
+    return canonicalName.substr(0, mapped.length) == mapped
+        && (canonicalName.length == mapped.length || canonicalName[mapped.length + 1] == '/');
+  }
+
+  Object.keys(loader.map).forEach(function(alias) {
+    if (getBestAlias(loader.map[alias]))
+      bestAlias = alias;
+  });
+
+  if (bestAlias)
+    return bestAlias;
+
+  Object.keys(loader.packages).forEach(function(pkg) {
+    Object.keys(loader.packages[pkg].map || {}).forEach(function(alias) {
+      if (getBestAlias(loader.packages[pkg].map[alias]))
+        bestAlias = alias;
+    });
+  });
+
+  return bestAlias || canonicalName;
 }
-exports.filePath = filePath;
 
-/* Coerce URLs to paths, assuming they are file URLs */
-function coercePath(url) {
-  if (isFileURL(url))
-    return url.replace(/^file:\/+/, '/');
-  else
-    // assume relative
-    return path.resolve(process.cwd(), url);
+exports.getCanonicalName = getCanonicalName;
+function getCanonicalName(loader, normalized, isPlugin) {
+  // 1. Boolean conditional
+  var booleanIndex = normalized.lastIndexOf('#?');
+  if (booleanIndex != -1) {
+    var booleanModule = normalized.substr(booleanIndex + 2);
+    var negate = booleanModule[0] == '~';
+    if (negate)
+      booleanModule = booleanModule.substr(1);
+    return getCanonicalName(loader, normalized.substr(0, booleanIndex)) + '#?' + (negate ? '~' : '') + canonicalizeCondition(loader, booleanModule);
+  }
+
+  // 2. Plugins
+  var pluginIndex = loader.pluginFirst ? normalized.indexOf('!') : normalized.lastIndexOf('!');
+  if (pluginIndex != -1)
+    return getCanonicalName(loader, normalized.substr(0, pluginIndex), !loader.pluginFirst) + '!' + getCanonicalName(loader, normalized.substr(pluginIndex + 1), loader.pluginFirst);
+
+  // 3. Package environment map
+  var pkgEnvIndex = normalized.indexOf('#:');
+  if (pkgEnvIndex != -1)
+    return getCanonicalName(loader, normalized.substr(0, pkgEnvIndex), isPlugin) + normalized.substr(pkgEnvIndex);
+
+  // Finally get canonical plain
+  var canonical = getCanonicalNamePlain(loader, normalized, isPlugin);
+
+  // 4. Canonicalize conditional interpolation
+  var conditionalMatch = canonical.match(interpolationRegEx);
+  if (conditionalMatch)
+    return getCanonicalNamePlain(loader, normalized, isPlugin).replace(interpolationRegEx, '#{' + canonicalizeCondition(loader, conditionalMatch[0].substr(2, conditionalMatch[0].length - 3)) + '}');
+
+  return canonical;
 }
-exports.coercePath = coercePath;
 
-var absURLRegEx = /^[^\/]+:\/\//;
-
-function normalizePath(loader, path, isPlugin) {
-  var curPath;
-  if (loader.paths[path][0] == '.')
-    curPath = decodeURI(url.resolve(toFileURL(process.cwd()) + '/', loader.paths[path]));
-  else
-    curPath = decodeURI(url.resolve(loader.baseURL, loader.paths[path]));
-  if (loader.defaultJSExtensions && !isPlugin && curPath.substr(curPath.length - 3, 3) != '.js')
-    curPath += '.js';
-  return curPath;
+// calculate the canonical name of the normalized module
+// unwraps loader syntaxes to derive component parts
+var interpolationRegEx = /#\{[^\}]+\}/;
+function canonicalizeCondition(loader, conditionModule) {
+  var conditionExport;
+  var exportIndex = conditionModule.lastIndexOf('|');
+  if (exportIndex != -1) {
+    conditionExport = conditionModule.substr(exportIndex + 1)
+    conditionModule = conditionModule.substr(0, exportIndex);
+  }
+  return getCanonicalName(loader, conditionModule) + (conditionExport ? '|' + conditionExport : '');
 }
 
 // syntax-free getCanonicalName
@@ -109,76 +149,18 @@ function getCanonicalNamePlain(loader, normalized, isPlugin) {
   return pathMatch;
 }
 
-exports.getCanonicalName = getCanonicalName;
-
-// calculate the canonical name of the normalized module
-// unwraps loader syntaxes to derive component parts
-var interpolationRegEx = /#\{[^\}]+\}/;
-function canonicalizeCondition(loader, conditionModule) {
-  var conditionExport;
-  var exportIndex = conditionModule.lastIndexOf('|');
-  if (exportIndex != -1) {
-    conditionExport = conditionModule.substr(exportIndex + 1)
-    conditionModule = conditionModule.substr(0, exportIndex);
-  }
-  return getCanonicalName(loader, conditionModule) + (conditionExport ? '|' + conditionExport : '');
+var absURLRegEx = /^[^\/]+:\/\//;
+function normalizePath(loader, path, isPlugin) {
+  var curPath;
+  if (loader.paths[path][0] == '.')
+    curPath = decodeURI(url.resolve(toFileURL(process.cwd()) + '/', loader.paths[path]));
+  else
+    curPath = decodeURI(url.resolve(loader.baseURL, loader.paths[path]));
+  if (loader.defaultJSExtensions && !isPlugin && curPath.substr(curPath.length - 3, 3) != '.js')
+    curPath += '.js';
+  return curPath;
 }
 
-function getCanonicalName(loader, normalized, isPlugin) {
-  // 1. Boolean conditional
-  var booleanIndex = normalized.lastIndexOf('#?');
-  if (booleanIndex != -1) {
-    var booleanModule = normalized.substr(booleanIndex + 2);
-    var negate = booleanModule[0] == '~';
-    if (negate)
-      booleanModule = booleanModule.substr(1);
-    return getCanonicalName(loader, normalized.substr(0, booleanIndex)) + '#?' + (negate ? '~' : '') + canonicalizeCondition(loader, booleanModule);
-  }
 
-  // 2. Plugins
-  var pluginIndex = loader.pluginFirst ? normalized.indexOf('!') : normalized.lastIndexOf('!');
-  if (pluginIndex != -1)
-    return getCanonicalName(loader, normalized.substr(0, pluginIndex), !loader.pluginFirst) + '!' + getCanonicalName(loader, normalized.substr(pluginIndex + 1), loader.pluginFirst);
 
-  // 3. Package environment map
-  var pkgEnvIndex = normalized.indexOf('#:');
-  if (pkgEnvIndex != -1)
-    return getCanonicalName(loader, normalized.substr(0, pkgEnvIndex), isPlugin) + normalized.substr(pkgEnvIndex);
 
-  // Finally get canonical plain
-  var canonical = getCanonicalNamePlain(loader, normalized, isPlugin);
-
-  // 4. Canonicalize conditional interpolation
-  var conditionalMatch = canonical.match(interpolationRegEx);
-  if (conditionalMatch)
-    return getCanonicalNamePlain(loader, normalized, isPlugin).replace(interpolationRegEx, '#{' + canonicalizeCondition(loader, conditionalMatch[0].substr(2, conditionalMatch[0].length - 3)) + '}');
-
-  return canonical;
-}
-
-exports.getAlias = getAlias
-function getAlias(loader, canonicalName) {
-  var bestAlias;
-
-  function getBestAlias(mapped) {
-    return canonicalName.substr(0, mapped.length) == mapped
-        && (canonicalName.length == mapped.length || canonicalName[mapped.length + 1] == '/');
-  }
-
-  Object.keys(loader.map).forEach(function(alias) {
-    if (getBestAlias(loader.map[alias]))
-      bestAlias = alias;
-  });
-
-  if (bestAlias)
-    return bestAlias;
-
-  Object.keys(loader.packages).forEach(function(pkg) {
-    Object.keys(loader.packages[pkg].map || {}).forEach(function(alias) {
-      if (getBestAlias(loader.packages[pkg].map[alias]))
-        bestAlias = alias;
-    });
-  });
-
-  return bestAlias || canonicalName;
-}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -202,7 +202,7 @@ function getGraphEntryPoints(graph, entryPoints) {
   return entryPoints;
 }
 
-exports.postOrderTraverseTree = function postOrderTraverseTree(tree, entryPoints) {
+exports.getTreeModulesPostOrder = function getTreeModulesPostOrder(tree, entryPoints) {
   entryPoints = entryPoints || [];
 
   // Post order traversal sorted module list
@@ -211,14 +211,14 @@ exports.postOrderTraverseTree = function postOrderTraverseTree(tree, entryPoints
 
   // Seed graph with all relations
   Object.keys(tree).forEach(function (moduleName) {
-    var module = tree[moduleName];
+    var load = tree[moduleName];
 
-    if (!graph.adjList[module.name]) {
-      graph.addVertex(module.name);
+    if (!graph.adjList[moduleName]) {
+      graph.addVertex(moduleName);
     }
 
-    module.deps.forEach(function (depName) {
-      graph.addEdge(module.name, module.depMap[depName]);
+    load.deps.forEach(function (depName) {
+      graph.addEdge(moduleName, load.depMap[depName]);
     });
   });
 
@@ -226,17 +226,12 @@ exports.postOrderTraverseTree = function postOrderTraverseTree(tree, entryPoints
   getGraphEntryPoints(graph, entryPoints).forEach(function (entryPoint) {
     depthFirst(graph, entryPoint, {
       leaveVertex: function (moduleName) {
-        // Avoidj duplicates
-        if (postOrder.indexOf(moduleName) === -1) {
+        // Avoid duplicates and modules that have been skipped by tracer
+        if (postOrder.indexOf(moduleName) === -1 && moduleName in tree) {
           postOrder.push(moduleName);
         }
       }
     });
-  });
-
-  // The graph some times includes things the tracer has already discarded. Filter those
-  postOrder = postOrder.filter(function (moduleName) {
-    return moduleName in tree;
   });
 
   return postOrder;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,9 +1,5 @@
 var path = require('path');
 var url = require('url');
-var trace = require('./trace');
-
-var Graph = require('algorithms/data_structures/graph');
-var depthFirst = require('algorithms/graph').depthFirstSearch;
 
 function fromFileURL(url) {
   return url.substr(7 + !!process.platform.match(/^win/)).replace(/\//g, path.sep);
@@ -179,61 +175,3 @@ function getAlias(loader, canonicalName) {
 
   return bestAlias || canonicalName;
 }
-
-function getGraphEntryPoints(graph, entryPoints) {
-  entryPoints = [].concat(entryPoints || []);
-
-  var modules = Object.keys(graph.adjList);
-  var discarded = {};
-
-  modules.forEach(function (moduleName) {
-    Object.keys(graph.adjList[moduleName]).forEach(function (depName) {
-      discarded[depName] = true;
-    });
-  });
-
-  modules.filter(function (moduleName) {
-    return !discarded[moduleName];
-  }).sort().forEach(function (moduleName) {
-    if (entryPoints.indexOf(moduleName) === -1) {
-      entryPoints.push(moduleName);
-    }
-  });
-
-  return entryPoints;
-}
-
-exports.getTreeModulesPostOrder = function getTreeModulesPostOrder(tree, entryPoints) {
-  entryPoints = entryPoints || [];
-
-  // Post order traversal sorted module list
-  var postOrder = [];
-  var graph = new Graph(true);
-
-  // Seed graph with all relations
-  Object.keys(tree).forEach(function (moduleName) {
-    var load = tree[moduleName];
-
-    if (!graph.adjList[moduleName]) {
-      graph.addVertex(moduleName);
-    }
-
-    trace.getLoadDependencies(load).forEach(function (depName) {
-      graph.addEdge(moduleName, depName);
-    });
-  });
-
-  // Post order traversal of graph, one per entryPoint
-  getGraphEntryPoints(graph, entryPoints).forEach(function (entryPoint) {
-    depthFirst(graph, entryPoint, {
-      leaveVertex: function (moduleName) {
-        // Avoid duplicates and modules that have been skipped by tracer
-        if (postOrder.indexOf(moduleName) === -1 && moduleName in tree) {
-          postOrder.push(moduleName);
-        }
-      }
-    });
-  });
-
-  return postOrder;
-};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -46,29 +46,13 @@ function normalizePath(loader, path) {
   return curPath;
 }
 
-exports.getCanonicalName = getCanonicalName;
-function getCanonicalName(loader, normalized) {
-  // remove the plugin part first
-  var plugin;
-  if (loader.pluginFirst) {
-    var pluginIndex = normalized.indexOf('!');
-    if (pluginIndex != -1) {
-      plugin = normalized.substr(0, pluginIndex);
-      normalized = normalized.substr(pluginIndex + 1);
-    }
-  }
-  else {
-    var pluginIndex = normalized.lastIndexOf('!');
-    if (pluginIndex != -1) {
-      plugin = normalized.substr(pluginIndex + 1);
-      normalized = normalized.substr(0, pluginIndex);
-    }
-  }
-
-  // add defaultJSExtension for reverse-pathing process to work out
+// syntax-free getCanonicalName
+// just reverse-applies paths and defulatJSExtension to determine the canonical
+function getCanonicalNamePlain(loader, normalized, isPlugin) {
+  // add defaultJSExtension for reverse-pathing defaultJSExtension process to work out
   // due to the fact that plugins remove defaultJSExtensions to begin with
   var defaultJSExtension = false;
-  if (plugin && loader.defaultJSExtensions && normalized.substr(normalized.length - 3, 3) != '.js') {
+  if (isPlugin && loader.defaultJSExtensions && normalized.substr(normalized.length - 3, 3) != '.js') {
     normalized += '.js';
     defaultJSExtension = true;
   }
@@ -123,19 +107,58 @@ function getCanonicalName(loader, normalized) {
       pathMatch = normalized;
   }
 
-  if (plugin) {
-    if (defaultJSExtension && pathMatch.substr(pathMatch.length - 3, 3) == '.js')
-      pathMatch = pathMatch.substr(0, pathMatch.length - 3);
-
-    if (loader.pluginFirst) {
-      pathMatch = getCanonicalName(loader, plugin) + '!' + pathMatch;
-    }
-    else {
-      pathMatch += '!' + getCanonicalName(loader, plugin);
-    }
-  }
+  // for plugins revert defaultJSExtension extension now
+  if (isPlugin && defaultJSExtension && pathMatch.substr(pathMatch.length - 3, 3) == '.js')
+    pathMatch = pathMatch.substr(0, pathMatch.length - 3);
 
   return pathMatch;
+}
+
+exports.getCanonicalName = getCanonicalName;
+
+// calculate the canonical name of the normalized module
+// unwraps loader syntaxes to derive component parts
+var interpolationRegEx = /#\{[^\}]+\}/;
+function canonicalizeCondition(loader, conditionModule) {
+  var conditionExport;
+  var exportIndex = conditionModule.lastIndexOf('|');
+  if (exportIndex != -1) {
+    conditionExport = conditionModule.substr(exportIndex + 1)
+    conditionModule = conditionModule.substr(0, exportIndex);
+  }
+  return getCanonicalName(loader, conditionModule) + (conditionExport ? '|' + conditionExport : '');
+}
+
+function getCanonicalName(loader, normalized) {
+  // 1. Boolean conditional
+  var booleanIndex = normalized.lastIndexOf('#?');
+  if (booleanIndex != -1) {
+    var booleanModule = normalized.substr(booleanIndex + 2);
+    var negate = booleanModule[0] == '~';
+    if (negate)
+      booleanModule = booleanModule.substr(1);
+    return getCanonicalName(loader, normalized.substr(0, booleanIndex) + '#?' + (negate ? '~' : '') + canonicalizeCondition(loader, booleanModule));
+  }
+
+  // 2. Plugins
+  var pluginIndex = loader.pluginFirst ? normalized.indexOf('!') : normalized.lastIndexOf('!');
+  if (pluginIndex != -1)
+    return getCanonicalName(loader, normalized.substr(0, pluginIndex), true) + '!' + getCanonicalName(loader, normalized.substr(pluginIndex + 1));
+
+  // 3. Package environment map
+  var pkgEnvIndex = normalized.indexOf('#:');
+  if (pkgEnvIndex != -1)
+    return getCanonicalName(loader, normalized.substr(0, pkgEnvIndex)) + normalized.substr(pkgEnvIndex);
+
+  // Finally get canonical plain
+  var canonical = getCanonicalNamePlain(loader, normalized);
+
+  // 4. Canonicalize conditional interpolation
+  var conditionalMatch = canonical.match(interpolationRegEx);
+  if (conditionalMatch)
+    return getCanonicalNamePlain(loader, normalized).replace(interpolationRegEx, '#{' + canonicalizeCondition(loader, conditionalMatch[0].substr(2, conditionalMatch[0].length - 3)) + '}');
+
+  return canonical;
 }
 
 exports.getAlias = getAlias

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -230,5 +230,10 @@ exports.postOrderTraverseTree = function postOrderTraverseTree(tree, loader, ent
     });
   });
 
+  // The graph some times includes things the tracer has already discarded. Filter those
+  postOrder = postOrder.filter(function (moduleName) {
+    return moduleName in tree;
+  });
+
   return postOrder;
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -202,7 +202,7 @@ function getGraphEntryPoints(graph, entryPoints) {
   return entryPoints;
 }
 
-exports.postOrderTraverseTree = function postOrderTraverseTree(tree, loader, entryPoints) {
+exports.postOrderTraverseTree = function postOrderTraverseTree(tree, entryPoints) {
   entryPoints = entryPoints || [];
 
   // Post order traversal sorted module list

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -49,14 +49,6 @@ function normalizePath(loader, path, isPlugin) {
 // syntax-free getCanonicalName
 // just reverse-applies paths and defulatJSExtension to determine the canonical
 function getCanonicalNamePlain(loader, normalized, isPlugin) {
-  // add defaultJSExtension for reverse-pathing defaultJSExtension process to work out
-  // due to the fact that plugins remove defaultJSExtensions to begin with
-  var defaultJSExtension = false;
-  if (!isPlugin && loader.defaultJSExtensions && normalized.substr(normalized.length - 3, 3) != '.js') {
-    normalized += '.js';
-    defaultJSExtension = true;
-  }
-
   // now just reverse apply paths rules to get canonical name
   var pathMatch;
 
@@ -133,7 +125,7 @@ function getCanonicalName(loader, normalized, isPlugin) {
     var negate = booleanModule[0] == '~';
     if (negate)
       booleanModule = booleanModule.substr(1);
-    return getCanonicalName(loader, normalized.substr(0, booleanIndex) + '#?' + (negate ? '~' : '') + canonicalizeCondition(loader, booleanModule), isPlugin);
+    return getCanonicalName(loader, normalized.substr(0, booleanIndex)) + '#?' + (negate ? '~' : '') + canonicalizeCondition(loader, booleanModule);
   }
 
   // 2. Plugins

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,13 @@
 var path = require('path');
 var url = require('url');
 
+exports.extend = extend;
+function extend(a, b) {
+  for (var p in b)
+    a[p] = b[p];
+  return a;
+}
+
 function fromFileURL(url) {
   return url.substr(7 + !!process.platform.match(/^win/)).replace(/\//g, path.sep);
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -88,7 +88,7 @@ function canonicalizeCondition(loader, conditionModule) {
   var exportIndex = conditionModule.lastIndexOf('|');
   if (exportIndex != -1) {
     conditionExport = conditionModule.substr(exportIndex + 1)
-    conditionModule = conditionModule.substr(0, exportIndex);
+    conditionModule = conditionModule.substr(0, exportIndex) || '@system-env';
   }
   return getCanonicalName(loader, conditionModule) + (conditionExport ? '|' + conditionExport : '');
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -35,13 +35,13 @@ exports.coercePath = coercePath;
 
 var absURLRegEx = /^[^\/]+:\/\//;
 
-function normalizePath(loader, path) {
+function normalizePath(loader, path, isPlugin) {
   var curPath;
   if (loader.paths[path][0] == '.')
     curPath = decodeURI(url.resolve(toFileURL(process.cwd()) + '/', loader.paths[path]));
   else
     curPath = decodeURI(url.resolve(loader.baseURL, loader.paths[path]));
-  if (loader.defaultJSExtensions && curPath.substr(curPath.length - 3, 3) != '.js')
+  if (loader.defaultJSExtensions && !isPlugin && curPath.substr(curPath.length - 3, 3) != '.js')
     curPath += '.js';
   return curPath;
 }
@@ -52,7 +52,7 @@ function getCanonicalNamePlain(loader, normalized, isPlugin) {
   // add defaultJSExtension for reverse-pathing defaultJSExtension process to work out
   // due to the fact that plugins remove defaultJSExtensions to begin with
   var defaultJSExtension = false;
-  if (isPlugin && loader.defaultJSExtensions && normalized.substr(normalized.length - 3, 3) != '.js') {
+  if (!isPlugin && loader.defaultJSExtensions && normalized.substr(normalized.length - 3, 3) != '.js') {
     normalized += '.js';
     defaultJSExtension = true;
   }
@@ -65,7 +65,7 @@ function getCanonicalNamePlain(loader, normalized, isPlugin) {
     if (loader.paths[p].indexOf('*') != -1)
       continue;
 
-    var curPath = normalizePath(loader, p);
+    var curPath = normalizePath(loader, p, isPlugin);
 
     if (normalized === curPath) {
       // always stop on first exact match
@@ -83,14 +83,14 @@ function getCanonicalNamePlain(loader, normalized, isPlugin) {
         continue;
 
       // normalize the output path
-      var curPath = normalizePath(loader, p);
+      var curPath = normalizePath(loader, p, isPlugin);
 
       // do reverse match
       var wIndex = curPath.indexOf('*');
       if (normalized.substr(0, wIndex) === curPath.substr(0, wIndex)
         && normalized.substr(normalized.length - curPath.length + wIndex + 1) === curPath.substr(wIndex + 1)) {
         curMatchLength = curPath.split('/').length;
-        if (curMatchLength > pathMatchLength) {
+        if (curMatchLength >= pathMatchLength) {
           pathMatch = p.replace('*', normalized.substr(wIndex, normalized.length - curPath.length + 1));
           pathMatchLength = curMatchLength;
         }
@@ -106,10 +106,6 @@ function getCanonicalNamePlain(loader, normalized, isPlugin) {
     else
       pathMatch = normalized;
   }
-
-  // for plugins revert defaultJSExtension extension now
-  if (isPlugin && defaultJSExtension && pathMatch.substr(pathMatch.length - 3, 3) == '.js')
-    pathMatch = pathMatch.substr(0, pathMatch.length - 3);
 
   return pathMatch;
 }
@@ -129,7 +125,7 @@ function canonicalizeCondition(loader, conditionModule) {
   return getCanonicalName(loader, conditionModule) + (conditionExport ? '|' + conditionExport : '');
 }
 
-function getCanonicalName(loader, normalized) {
+function getCanonicalName(loader, normalized, isPlugin) {
   // 1. Boolean conditional
   var booleanIndex = normalized.lastIndexOf('#?');
   if (booleanIndex != -1) {
@@ -137,26 +133,26 @@ function getCanonicalName(loader, normalized) {
     var negate = booleanModule[0] == '~';
     if (negate)
       booleanModule = booleanModule.substr(1);
-    return getCanonicalName(loader, normalized.substr(0, booleanIndex) + '#?' + (negate ? '~' : '') + canonicalizeCondition(loader, booleanModule));
+    return getCanonicalName(loader, normalized.substr(0, booleanIndex) + '#?' + (negate ? '~' : '') + canonicalizeCondition(loader, booleanModule), isPlugin);
   }
 
   // 2. Plugins
   var pluginIndex = loader.pluginFirst ? normalized.indexOf('!') : normalized.lastIndexOf('!');
   if (pluginIndex != -1)
-    return getCanonicalName(loader, normalized.substr(0, pluginIndex), true) + '!' + getCanonicalName(loader, normalized.substr(pluginIndex + 1));
+    return getCanonicalName(loader, normalized.substr(0, pluginIndex), !loader.pluginFirst) + '!' + getCanonicalName(loader, normalized.substr(pluginIndex + 1), loader.pluginFirst);
 
   // 3. Package environment map
   var pkgEnvIndex = normalized.indexOf('#:');
   if (pkgEnvIndex != -1)
-    return getCanonicalName(loader, normalized.substr(0, pkgEnvIndex)) + normalized.substr(pkgEnvIndex);
+    return getCanonicalName(loader, normalized.substr(0, pkgEnvIndex), isPlugin) + normalized.substr(pkgEnvIndex);
 
   // Finally get canonical plain
-  var canonical = getCanonicalNamePlain(loader, normalized);
+  var canonical = getCanonicalNamePlain(loader, normalized, isPlugin);
 
   // 4. Canonicalize conditional interpolation
   var conditionalMatch = canonical.match(interpolationRegEx);
   if (conditionalMatch)
-    return getCanonicalNamePlain(loader, normalized).replace(interpolationRegEx, '#{' + canonicalizeCondition(loader, conditionalMatch[0].substr(2, conditionalMatch[0].length - 3)) + '}');
+    return getCanonicalNamePlain(loader, normalized, isPlugin).replace(interpolationRegEx, '#{' + canonicalizeCondition(loader, conditionalMatch[0].substr(2, conditionalMatch[0].length - 3)) + '}');
 
   return canonical;
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -213,6 +213,10 @@ exports.postOrderTraverseTree = function postOrderTraverseTree(tree, entryPoints
   Object.keys(tree).forEach(function (moduleName) {
     var module = tree[moduleName];
 
+    if (!graph.adjList[module.name]) {
+      graph.addVertex(module.name);
+    }
+
     module.deps.forEach(function (depName) {
       graph.addEdge(module.name, module.depMap[depName]);
     });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,6 @@
 var path = require('path');
 var url = require('url');
+var trace = require('./trace');
 
 var Graph = require('algorithms/data_structures/graph');
 var depthFirst = require('algorithms/graph').depthFirstSearch;
@@ -217,8 +218,8 @@ exports.getTreeModulesPostOrder = function getTreeModulesPostOrder(tree, entryPo
       graph.addVertex(moduleName);
     }
 
-    load.deps.forEach(function (depName) {
-      graph.addEdge(moduleName, load.depMap[depName]);
+    trace.getLoadDependencies(load).forEach(function (depName) {
+      graph.addEdge(moduleName, depName);
     });
   });
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,9 @@
 var path = require('path');
 var url = require('url');
 
+var Graph = require('algorithms/data_structures/graph');
+var depthFirst = require('algorithms/graph').depthFirstSearch;
+
 function fromFileURL(url) {
   return url.substr(7 + !!process.platform.match(/^win/)).replace(/\//g, path.sep);
 }
@@ -175,3 +178,57 @@ function getAlias(loader, canonicalName) {
 
   return bestAlias || canonicalName;
 }
+
+function getGraphEntryPoints(graph, entryPoints) {
+  entryPoints = [].concat(entryPoints || []);
+
+  var modules = Object.keys(graph.adjList);
+  var discarded = {};
+
+  modules.forEach(function (moduleName) {
+    Object.keys(graph.adjList[moduleName]).forEach(function (depName) {
+      discarded[depName] = true;
+    });
+  });
+
+  modules.filter(function (moduleName) {
+    return !discarded[moduleName];
+  }).sort().forEach(function (moduleName) {
+    if (entryPoints.indexOf(moduleName) === -1) {
+      entryPoints.push(moduleName);
+    }
+  });
+
+  return entryPoints;
+}
+
+exports.postOrderTraverseTree = function postOrderTraverseTree(tree, loader, entryPoints) {
+  entryPoints = entryPoints || [];
+
+  // Post order traversal sorted module list
+  var postOrder = [];
+  var graph = new Graph(true);
+
+  // Seed graph with all relations
+  Object.keys(tree).forEach(function (moduleName) {
+    var module = tree[moduleName];
+
+    module.deps.forEach(function (depName) {
+      graph.addEdge(module.name, module.depMap[depName]);
+    });
+  });
+
+  // Post order traversal of graph, one per entryPoint
+  getGraphEntryPoints(graph, entryPoints).forEach(function (entryPoint) {
+    depthFirst(graph, entryPoint, {
+      leaveVertex: function (moduleName) {
+        // Avoidj duplicates
+        if (postOrder.indexOf(moduleName) === -1) {
+          postOrder.push(moduleName);
+        }
+      }
+    });
+  });
+
+  return postOrder;
+};

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "mocha": "^2.2.5",
     "mocha-phantomjs": "3.5.6",
     "phantomjs": "1.9.18",
-    "typescript": "next"
+    "typescript": "next",
+    "unexpected": "^9.11.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "mkdirp": "^0.5.1",
     "rsvp": "^3.0.20",
     "source-map": "^0.4.4",
-    "systemjs": "^0.18.13",
+    "systemjs": "git://github.com/systemjs/systemjs#master",
     "traceur": "0.0.91",
     "uglify-js": "^2.4.23"
   },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "SystemJS Build Tool",
   "main": "index.js",
   "dependencies": {
+    "algorithms": "^0.9.1",
     "es6-template-strings": "^1.0.0",
     "glob": "^5.0.14",
     "mkdirp": "^0.5.1",

--- a/templates/sfx-core.js
+++ b/templates/sfx-core.js
@@ -352,6 +352,10 @@
     if (modules[name])
       return modules[name];
 
+    // node core modules
+    if (name.substr(0, 6) == '@node/')
+      return require(name.substr(6));
+
     var entry = defined[name];
 
     // first we check if this module has already been defined in the registry

--- a/templates/sfx-global.js
+++ b/templates/sfx-global.js
@@ -1,3 +1,3 @@
 (function(factory) {
-  ${sfxGlobalName ? sfxGlobalName + ' = ' : ''}factory(${sfxGlobals.join(', ')});
+  ${globalName ? globalName + ' = ' : ''}factory(${globalDeps.join(', ')});
 });

--- a/test/anon-compile.js
+++ b/test/anon-compile.js
@@ -22,14 +22,14 @@ suite('Anonymous Compilation', function() {
 
   test('Global', function(done) {
     builder.compile('global.js').then(function(output) {
-      assert.match(output.source, /System\.registerDynamic\(\["jquery\.js"/);
+      assert.match(output.source, /System\.registerDynamic\(\["\.\/jquery\.js"/);
     })
     .then(done, done);
   });
 
   test('Register', function(done) {
     builder.compile('third.js').then(function(output) {
-      assert.match(output.source, /System\.register\(\["second.js"\]/);
+      assert.match(output.source, /System\.register\(\["\.\/second.js"\]/);
     })
     .then(done, done);
   });

--- a/test/arithmetic.js
+++ b/test/arithmetic.js
@@ -37,7 +37,7 @@ suite('Bundle Expressions', function() {
     .then(function(tree) {
       assert.deepEqual(Object.keys(tree).sort(), [
           'Buffer.js', 'amd.js', 'babel', 'cjs-globals.js', 'cjs.js', 'component.jsx!jsx.js', 'first.js', 
-          'global-inner.js', 'global-outer.js', 'global.js', 'jquery.js', 'jsx.js', 'plugin.js', 'runtime.js', 
+          'global-inner.js', 'global-outer.js', 'global.js', 'jquery-cdn', 'jquery.js', 'jsx.js', 'plugin.js', 'runtime.js', 
           'second.js', 'some.js!plugin.js', 'text-plugin.js', 'text.txt!text-plugin.js', 'third.js', 'umd.js']);
     })
     .then(done, done);

--- a/test/canonicals.js
+++ b/test/canonicals.js
@@ -26,7 +26,7 @@ suite('Canonical Names', function() {
 
   test('Wildcard extensions with a plugin', function() {
     builder.loader.defaultJSExtensions = true;
-    assert.equal(builder.getCanonicalName('cjs'), 'cjs');
+    assert.equal(builder.getCanonicalName('cjs'), 'cjs.js');
     assert.equal(builder.getCanonicalName(baseURL + 'test/dummy/file.jade!' + baseURL + 'test/fixtures/test-tree/jade.js'), 'file.jade!jade');
   });
 });

--- a/test/canonicals.js
+++ b/test/canonicals.js
@@ -26,7 +26,7 @@ suite('Canonical Names', function() {
 
   test('Wildcard extensions with a plugin', function() {
     builder.loader.defaultJSExtensions = true;
-    assert.equal(builder.getCanonicalName('cjs'), 'cjs.js');
+    assert.equal(builder.getCanonicalName('cjs'), 'cjs');
     assert.equal(builder.getCanonicalName(baseURL + 'test/dummy/file.jade!' + baseURL + 'test/fixtures/test-tree/jade.js'), 'file.jade!jade');
   });
 });

--- a/test/conditional-builds.js
+++ b/test/conditional-builds.js
@@ -1,0 +1,23 @@
+var Builder = require('../index');
+
+var builder = new Builder('test/fixtures/conditional-tree');
+
+builder.loadConfigSync('test/fixtures/conditional-tree.config.js');
+
+suite('Conditional Builds', function() {  
+  test('Package environment traces all conditional variations', function() {
+    return builder.trace('pkg/env-condition')
+    .then(function(trace) {
+      assert.deepEqual(Object.keys(trace).sort(), ['pkg#:env-condition', '@system-env', 'pkg/env-condition-browser.js', 'pkg/env-condition.js'].sort());
+    });
+  });
+
+  // return builder.trace('pkg/env-condition!plugin')
+
+  test('Conditional interpolation traces all conditional variations', function() {
+    return builder.trace('interpolated-#{conditions.js|test}.js')
+    .then(function(trace) {
+      assert.deepEqual(Object.keys(trace).sort(), [ 'interpolated-#{conditions.js|test}.js', 'conditions.js', 'interpolated-1.js', 'interpolated-2.js' ].sort());
+    });
+  });
+});

--- a/test/conditional-builds.js
+++ b/test/conditional-builds.js
@@ -12,8 +12,6 @@ suite('Conditional Builds', function() {
     });
   });
 
-  // return builder.trace('pkg/env-condition!plugin')
-
   test('Conditional interpolation traces all conditional variations', function() {
     return builder.trace('interpolated-#{conditions.js|test}.js')
     .then(function(trace) {

--- a/test/conditional-builds.js
+++ b/test/conditional-builds.js
@@ -15,17 +15,42 @@ suite('Conditional Builds', function() {
   test('Conditional interpolation traces all conditional variations', function() {
     return builder.trace('interpolated-#{conditions.js|test}.js')
     .then(function(tree) {
-      assert.deepEqual(Object.keys(tree).sort(), [ 'interpolated-#{conditions.js|test}.js', 'conditions.js', 'interpolated-1.js', 'interpolated-2.js' ].sort());
+      assert.deepEqual(Object.keys(tree).sort(), ['interpolated-#{conditions.js|test}.js', 'conditions.js', 'interpolated-1.js', 'interpolated-2.js'].sort());
+    });
+  });
+
+  test('traceAllConditionals false', function() {
+    return builder.trace('pkg/env-condition + interpolated-#{conditions.js|test}.js', { traceAllConditionals: false })
+    .then(function(tree) {
+      assert.deepEqual(Object.keys(tree).sort(), ['interpolated-#{conditions.js|test}.js', 'pkg#:env-condition', 'conditions.js', 'pkg/env-condition.js'].sort());
+    });
+  });
+
+  test('Browser:false tracing', function() {
+    return builder.trace('pkg/env-condition + interpolated-#{conditions.js|test}.js', { browser: false })
+    .then(function(tree) {
+      assert.deepEqual(Object.keys(tree).sort(), ['pkg#:env-condition', 'pkg/env-condition.js', 'interpolated-#{conditions.js|test}.js', 'conditions.js', 'interpolated-1.js', 'interpolated-2.js'].sort())
+    });
+  });
+
+  test('Custom conditions trace', function() {
+    return builder.trace('interpolated-#{conditions.js|test}.js', { conditions: { 'conditions.js': { 'test': '1' } } })
+    .then(function(tree) {
+      assert.deepEqual(Object.keys(tree).sort(), ['interpolated-#{conditions.js|test}.js', 'conditions.js', 'interpolated-1.js'].sort());
     });
   });
 
   test('Environment tracing', function() {
-
+    return builder.trace('pkg/env-condition + interpolated-#{conditions.js|test}.js', { traceConditionsOnly: true })
+    .then(function(tree) {
+      assert.deepEqual(Object.keys(tree), ['conditions.js']);
+    });
   });
 
-  test('Build by default includes all conditional variations', function() {
-  });
-
-  test('Build with browser: true option includes only browser variations', function() {
+  test('Build including all conditional variations', function() {
+    return builder.bundle('pkg/env-condition + interpolated-#{conditions.js|test}.js', 'test/output/conditional-build.js', { sourceMaps: true })
+    .then(function(output) {
+      assert(output.source);
+    });
   });
 });

--- a/test/conditional-builds.js
+++ b/test/conditional-builds.js
@@ -8,7 +8,7 @@ suite('Conditional Builds', function() {
   test('Package environment traces all conditional variations', function() {
     return builder.trace('pkg/env-condition')
     .then(function(trace) {
-      assert.deepEqual(Object.keys(trace).sort(), ['pkg#:env-condition', '@system-env', 'pkg/env-condition-browser.js', 'pkg/env-condition.js'].sort());
+      assert.deepEqual(Object.keys(trace).sort(), ['pkg#:env-condition', 'pkg/env-condition-browser.js', 'pkg/env-condition.js'].sort());
     });
   });
 

--- a/test/conditional-builds.js
+++ b/test/conditional-builds.js
@@ -7,15 +7,25 @@ builder.loadConfigSync('test/fixtures/conditional-tree.config.js');
 suite('Conditional Builds', function() {  
   test('Package environment traces all conditional variations', function() {
     return builder.trace('pkg/env-condition')
-    .then(function(trace) {
-      assert.deepEqual(Object.keys(trace).sort(), ['pkg#:env-condition', 'pkg/env-condition-browser.js', 'pkg/env-condition.js'].sort());
+    .then(function(tree) {
+      assert.deepEqual(Object.keys(tree).sort(), ['pkg#:env-condition', 'pkg/env-condition-browser.js', 'pkg/env-condition.js'].sort());
     });
   });
 
   test('Conditional interpolation traces all conditional variations', function() {
     return builder.trace('interpolated-#{conditions.js|test}.js')
-    .then(function(trace) {
-      assert.deepEqual(Object.keys(trace).sort(), [ 'interpolated-#{conditions.js|test}.js', 'conditions.js', 'interpolated-1.js', 'interpolated-2.js' ].sort());
+    .then(function(tree) {
+      assert.deepEqual(Object.keys(tree).sort(), [ 'interpolated-#{conditions.js|test}.js', 'conditions.js', 'interpolated-1.js', 'interpolated-2.js' ].sort());
     });
+  });
+
+  test('Environment tracing', function() {
+
+  });
+
+  test('Build by default includes all conditional variations', function() {
+  });
+
+  test('Build with browser: true option includes only browser variations', function() {
   });
 });

--- a/test/conditional-builds.js
+++ b/test/conditional-builds.js
@@ -15,19 +15,19 @@ suite('Conditional Builds', function() {
   test('Conditional interpolation traces all conditional variations', function() {
     return builder.trace('interpolated-#{conditions.js|test}.js')
     .then(function(tree) {
-      assert.deepEqual(Object.keys(tree).sort(), ['interpolated-#{conditions.js|test}.js', 'conditions.js', 'interpolated-1.js', 'interpolated-2.js'].sort());
+      assert.deepEqual(Object.keys(tree).sort(), ['interpolated-#{conditions.js|test}.js', 'conditions.js', 'interpolated-1.js', 'interpolate-1-dep.js', 'interpolated-2.js'].sort());
     });
   });
 
   test('Boolean conditional', function() {
     return builder.trace('interpolated-1.js#?|browser')
     .then(function(tree) {
-      assert.deepEqual(Object.keys(tree).sort(), ['interpolated-1.js#?@system-env|browser', 'interpolated-1.js'].sort());
+      assert.deepEqual(Object.keys(tree).sort(), ['interpolated-1.js#?@system-env|browser', 'interpolated-1.js', 'interpolate-1-dep.js'].sort());
     });
   });
 
   test('Boolean conditional exclusion', function() {
-    return builder.trace('interpolated-1.js#?|browser', { browser: false })
+    return builder.trace('interpolated-1.js#?|browser', { node: true })
     .then(function(tree) {
       assert.deepEqual(Object.keys(tree), ['interpolated-1.js#?@system-env|browser']);
     })
@@ -43,14 +43,14 @@ suite('Conditional Builds', function() {
   test('Browser:false tracing', function() {
     return builder.trace('pkg/env-condition + interpolated-#{conditions.js|test}.js', { browser: false })
     .then(function(tree) {
-      assert.deepEqual(Object.keys(tree).sort(), ['pkg#:env-condition', 'pkg/env-condition.js', 'interpolated-#{conditions.js|test}.js', 'conditions.js', 'interpolated-1.js', 'interpolated-2.js'].sort())
+      assert.deepEqual(Object.keys(tree).sort(), ['pkg#:env-condition', 'pkg/env-condition.js', 'interpolated-#{conditions.js|test}.js', 'conditions.js', 'interpolated-1.js', 'interpolate-1-dep.js', 'interpolated-2.js'].sort())
     });
   });
 
   test('Custom conditions trace', function() {
     return builder.trace('interpolated-#{conditions.js|test}.js', { conditions: { 'conditions.js': { 'test': '1' } } })
     .then(function(tree) {
-      assert.deepEqual(Object.keys(tree).sort(), ['interpolated-#{conditions.js|test}.js', 'conditions.js', 'interpolated-1.js'].sort());
+      assert.deepEqual(Object.keys(tree).sort(), ['interpolated-#{conditions.js|test}.js', 'conditions.js', 'interpolated-1.js', 'interpolate-1-dep.js'].sort());
     });
   });
 

--- a/test/conditional-builds.js
+++ b/test/conditional-builds.js
@@ -24,6 +24,13 @@ suite('Conditional Builds', function() {
     .then(function(tree) {
       assert.deepEqual(Object.keys(tree).sort(), ['interpolated-1.js#?@system-env|browser', 'interpolated-1.js'].sort());
     });
+  });
+
+  test('Boolean conditional exclusion', function() {
+    return builder.trace('interpolated-1.js#?|browser', { browser: false })
+    .then(function(tree) {
+      assert.deepEqual(Object.keys(tree), ['interpolated-1.js#?@system-env|browser']);
+    })
   })
 
   test('traceAllConditionals false', function() {

--- a/test/conditional-builds.js
+++ b/test/conditional-builds.js
@@ -19,6 +19,13 @@ suite('Conditional Builds', function() {
     });
   });
 
+  test('Boolean conditional', function() {
+    return builder.trace('interpolated-1.js#?|browser')
+    .then(function(tree) {
+      assert.deepEqual(Object.keys(tree).sort(), ['interpolated-1.js#?@system-env|browser', 'interpolated-1.js'].sort());
+    });
+  })
+
   test('traceAllConditionals false', function() {
     return builder.trace('pkg/env-condition + interpolated-#{conditions.js|test}.js', { traceAllConditionals: false })
     .then(function(tree) {

--- a/test/conditional-canonicals.js
+++ b/test/conditional-canonicals.js
@@ -1,0 +1,33 @@
+var Builder = require('../index');
+
+var builder = new Builder('test/fixtures/conditional-tree');
+builder.loadConfigSync('test/fixtures/conditional-tree.config.js');
+
+var baseURL = builder.loader.baseURL;
+
+builder.config({ defaultJSExtensions: true });
+
+suite('Conditional Canonical Names', function() {
+  test('Package environment canonical', function() {
+    assert.equal(builder.getCanonicalName(baseURL + 'pkg#:env-condition'), 'pkg#:env-condition');
+  });
+  test('Interpolation', function() {
+    assert.equal(builder.getCanonicalName(baseURL + 'interpolated-#{' + baseURL + 'conditions.js|test}.js'), 'interpolated-#{conditions.js|test}.js');
+  });
+  test('Plugin interpolation', function() {
+    assert.equal(builder.getCanonicalName(baseURL + 'pkg/test-#{' + baseURL + 'conditions.js|test}.js!plugin-#{conditions.js|another}.js'), 'pkg/test-#{conditions.js|test}.js!plugin-#{conditions.js|another}.js');
+  });
+  test('Boolean conditional', function() {
+    assert.equal(builder.getCanonicalName(baseURL + 'pkg/test#?~' + baseURL + 'bool|exp'), 'pkg/test#?~bool|exp');
+  });
+  test('Boolean conditional with plugin', function() {
+    builder.config({
+      paths: {
+        a: 'asdf', // only if we add .js this catches
+        condition: 'conditions.js',
+        p: 'plugin'
+      }
+    })
+    assert.equal(builder.getCanonicalName(baseURL + 'asdf.js' + '!' + baseURL + 'plugin.js#?' + baseURL + 'conditions.js'), 'asdf.js!p#?condition');
+  })
+});

--- a/test/fixtures/conditional-tree.config.js
+++ b/test/fixtures/conditional-tree.config.js
@@ -1,0 +1,14 @@
+System.config({
+  map: {
+    condition: 'conditions.js'
+  },
+  packages: {
+    'pkg': {
+      map: {
+        './env-condition': {
+          'browser': './env-condition-browser'
+        }
+      }
+    }
+  }
+});

--- a/test/fixtures/conditional-tree/conditions.js
+++ b/test/fixtures/conditional-tree/conditions.js
@@ -1,0 +1,1 @@
+export var test = '1';

--- a/test/fixtures/conditional-tree/interpolate-1-dep.js
+++ b/test/fixtures/conditional-tree/interpolate-1-dep.js
@@ -1,0 +1,1 @@
+module.exports = '1-dep';

--- a/test/fixtures/conditional-tree/interpolated-1.js
+++ b/test/fixtures/conditional-tree/interpolated-1.js
@@ -1,0 +1,1 @@
+module.exports = '1';

--- a/test/fixtures/conditional-tree/interpolated-1.js
+++ b/test/fixtures/conditional-tree/interpolated-1.js
@@ -1,1 +1,2 @@
+require('./interpolate-1-dep.js');
 module.exports = '1';

--- a/test/fixtures/conditional-tree/interpolated-2.js
+++ b/test/fixtures/conditional-tree/interpolated-2.js
@@ -1,0 +1,1 @@
+export default 2;

--- a/test/fixtures/conditional-tree/pkg/env-condition-browser.js
+++ b/test/fixtures/conditional-tree/pkg/env-condition-browser.js
@@ -1,0 +1,1 @@
+module.exports = 'environment condition browser';

--- a/test/fixtures/conditional-tree/pkg/env-condition.js
+++ b/test/fixtures/conditional-tree/pkg/env-condition.js
@@ -1,0 +1,1 @@
+module.exports = 'environment condition';

--- a/test/fixtures/test-tree.config.js
+++ b/test/fixtures/test-tree.config.js
@@ -1,7 +1,4 @@
 System.config({
-  map: {
-    'jquery-cdn': '@empty'
-  },
   paths: {
     '*': './test/fixtures/test-tree/*',
     '*.jade': './test/dummy/*.jade',

--- a/test/test-build-cache.js
+++ b/test/test-build-cache.js
@@ -14,23 +14,23 @@ suite('Test compiler cache', function() {
 
     return builder.trace(loadName).then(function(_tree) {
       tree = _tree;
-      return builder.buildTree(tree);
+      return builder.bundle(tree);
     })
     .then(function() {
       var cacheEntry = builder.getCache();
 
       expect(cacheEntry).to.be.an('object');
 
-      cacheObj = cacheEntry.compile['simple.js'];
+      cacheObj = cacheEntry.compile.loads['simple.js'];
       
       expect(cacheObj).to.be.an('object');
-      expect(cacheObj.sourceHash).to.be.a('string');
+      expect(cacheObj.hash).to.be.a('string');
       expect(cacheObj.output).to.be.an('object');
 
       // poison cache
       cacheObj.output.source = cacheObj.output.source.replace('hate', 'love');
 
-      return builder.buildTree(tree);
+      return builder.bundle(tree);
     })
     .then(function(output) {
       // verify buildTree use poisoned cache rather than recompiling
@@ -39,8 +39,8 @@ suite('Test compiler cache', function() {
       expect(outputSource).to.contain('love caches');
 
       // invalidate poisoned cache entry and rebuild
-      cacheObj.sourceHash = 'out of date';
-      return builder.buildTree(tree);
+      cacheObj.hash = 'out of date';
+      return builder.bundle(tree);
     })
     .then(function(output) {
       // verify original source is used once more
@@ -52,13 +52,11 @@ suite('Test compiler cache', function() {
 
   test('Use trace cache when available', function() {
     // construct the load record for the cache
-    var fileName = toFileURL(__dirname + '/fixtures/test-cache-tree/simple.js');
     var cacheObj = {
       trace: {
         'simple.js': { 
           name: 'simple.js',
-          normalized: fileName,
-          address: fileName,
+          path: 'fixtures/test-cache-tree/simple.js',
           metadata: {
             deps: [],
             format: 'amd',
@@ -75,7 +73,7 @@ suite('Test compiler cache', function() {
     builder.reset();
     builder.setCache(cacheObj);
 
-    return builder.build('simple.js').then(function(output) {
+    return builder.bundle('simple.js').then(function(output) {
       expect(output.source).to.contain('fake cache');
     });
 

--- a/test/test-build.js
+++ b/test/test-build.js
@@ -35,7 +35,7 @@ function doTests(transpiler) {
     builder.config({ transpiler: transpiler });
     return builder.bundle('first.js', { sourceMaps: true, minify: minify })
     .then(function(output) {
-      fs.writeFileSync('test/output/memory-test.js', inline(output));
+      fs.writeFileSync('test/output/memory-test.js', inline(output.source, output.sourceMap));
     });
   });
 

--- a/test/test-build.js
+++ b/test/test-build.js
@@ -14,11 +14,7 @@ var err = function(e) {
   });
 };
 
-var builder = new Builder('test/fixtures/test-tree');
-
-var cfg;
-eval('(function() { System.config = function(_cfg){ cfg = _cfg }; '
-    + fs.readFileSync('test/fixtures/test-tree.config.js') + ' })();');
+var builder = new Builder('test/fixtures/test-tree', 'test/fixtures/test-tree.config.js');
 
 function testPhantom(html) {
   return new Promise(function(resolve, reject) {
@@ -36,9 +32,8 @@ function doTests(transpiler) {
 
   test('In-memory build', function() {
     builder.reset();
-    builder.config(cfg);
     builder.config({ transpiler: transpiler });
-    return builder.build('first.js', { sourceMaps: true, minify: minify })
+    return builder.bundle('first.js', { sourceMaps: true, minify: minify })
     .then(function(output) {
       fs.writeFileSync('test/output/memory-test.js', inline(output));
     });
@@ -46,99 +41,98 @@ function doTests(transpiler) {
 
   test('Multi-format tree build', function() {
     builder.reset();
-    builder.config(cfg);
     builder.config({ transpiler: transpiler });
 
-    return builder.build('first.js', 'test/output/tree-build.js', { sourceMaps: true, minify: minify, globalDefs: { DEBUG: false } })
+    return builder.bundle('first.js', 'test/output/tree-build.js', { sourceMaps: true, minify: minify, globalDefs: { DEBUG: false } })
     .then(function() {
       var treeFirst;
       Promise.all(['first.js', 'amd.js'].map(builder.trace.bind(builder)))
       .then(function(trees) {
         treeFirst = trees[0];
-        return builder.buildTree(builder.subtractTrees(trees[0], trees[1]), 'test/output/excluded.js');
+        return builder.bundle(builder.subtractTrees(trees[0], trees[1]), 'test/output/excluded.js');
       })
 
       .then(function() {
         return builder.trace('global-inner.js').then(function(tree) {
-          return builder.buildTree(tree, 'test/output/global-inner.js');
+          return builder.bundle(tree, 'test/output/global-inner.js');
         });
       })
 
       .then(function() {
         return builder.trace('global-outer.js').then(function(tree) {
-          return builder.buildTree(tree, 'test/output/global-outer.js');
+          return builder.bundle(tree, 'test/output/global-outer.js');
         });
       })
 
       .then(function() {
         return builder.trace('amd-1.js').then(function(tree) {
-          return builder.buildTree(builder.subtractTrees(tree, treeFirst), 'test/output/amd-1.js');
+          return builder.bundle(builder.subtractTrees(tree, treeFirst), 'test/output/amd-1.js');
         });
       })
 
       .then(function() {
         return builder.trace('amd-2.js').then(function(tree) {
-          return builder.buildTree(builder.subtractTrees(tree, treeFirst), 'test/output/amd-2.js');
+          return builder.bundle(builder.subtractTrees(tree, treeFirst), 'test/output/amd-2.js');
         });
       })
 
       .then(function() {
         return builder.trace('amd-3.js').then(function(tree) {
-          return builder.buildTree(builder.subtractTrees(tree, treeFirst), 'test/output/amd-3.js');
+          return builder.bundle(builder.subtractTrees(tree, treeFirst), 'test/output/amd-3.js');
         });
       })
 
       .then(function() {
         return builder.trace('amd-4.js').then(function(tree) {
-          return builder.buildTree(builder.subtractTrees(tree, treeFirst), 'test/output/amd-4.js');
+          return builder.bundle(builder.subtractTrees(tree, treeFirst), 'test/output/amd-4.js');
         });
       })
 
       .then(function() {
         return builder.trace('amd-5a.js').then(function(tree) {
-          return builder.buildTree(builder.subtractTrees(tree, treeFirst), 'test/output/amd-5a.js');
+          return builder.bundle(builder.subtractTrees(tree, treeFirst), 'test/output/amd-5a.js');
         });
       })
 
       .then(function() {
         return builder.trace('amd-5b.js').then(function(tree) {
-          return builder.buildTree(builder.subtractTrees(tree, treeFirst), 'test/output/amd-5b.js');
+          return builder.bundle(builder.subtractTrees(tree, treeFirst), 'test/output/amd-5b.js');
         });
       })
 
 
       .then(function() {
         return builder.trace('amd-6a.js').then(function(tree) {
-          return builder.buildTree(builder.subtractTrees(tree, treeFirst), 'test/output/amd-6a.js');
+          return builder.bundle(builder.subtractTrees(tree, treeFirst), 'test/output/amd-6a.js');
         });
       })
 
       .then(function() {
         return builder.trace('amd-6b.js').then(function(tree) {
-          return builder.buildTree(builder.subtractTrees(tree, treeFirst), 'test/output/amd-6b.js');
+          return builder.bundle(builder.subtractTrees(tree, treeFirst), 'test/output/amd-6b.js');
         });
       })
 
       .then(function() {
         return builder.trace('umd.js').then(function(tree) {
-          return builder.buildTree(builder.subtractTrees(tree, treeFirst), 'test/output/umd.js');
+          return builder.bundle(builder.subtractTrees(tree, treeFirst), 'test/output/umd.js');
         });
       })
 
       .then(function() {
-        return builder.build('amd-7.js', 'test/output/amd-7.js');
+        return builder.bundle('amd-7.js', 'test/output/amd-7.js');
       })
 
       .then(function() {
-        return builder.build('amd-8.js', 'test/output/amd-8.js');
+        return builder.bundle('amd-8.js', 'test/output/amd-8.js');
       })
 
       .then(function() {
-        return builder.build('cjs-globals.js', 'test/output/cjs-globals.js');
+        return builder.bundle('cjs-globals.js', 'test/output/cjs-globals.js');
       })
 
       .then(function() {
-        return builder.build('runtime.js', 'test/output/runtime.js');
+        return builder.bundle('runtime.js', 'test/output/runtime.js');
       })
     })
     .then(function () {
@@ -153,7 +147,6 @@ function doTests(transpiler) {
   if (transpiler != 'traceur')
   test('SFX tree build', function() {
     builder.reset();
-    builder.config(cfg);
     builder.config({transpiler: transpiler });
     builder.config({
       map: {
@@ -161,7 +154,7 @@ function doTests(transpiler) {
         'toamd1': 'amd-1.js'
       }
     });
-    return builder.buildSFX('toamd1', 'test/output/sfx.js', { runtime: true, minify: minify, globalDefs: { DEBUG: false } })
+    return builder.build('toamd1', 'test/output/sfx.js', { runtime: true, minify: minify, globalDefs: { DEBUG: false } })
     .then(function() {
       return testPhantom('test/test-sfx.html');
     });
@@ -190,7 +183,7 @@ suite('Bundle Format', function() {
   test('Test AMD format', function() {
     return Promise.resolve()
     .then(function() {
-      return builder.buildSFX('sfx-format-01.js', 'test/output/sfx-amd.js', { sfxFormat: 'amd' });
+      return builder.build('sfx-format-01.js', 'test/output/sfx-amd.js', { format: 'amd' });
     })
     .then(function() {
       return testPhantom('test/test-sfx-amd.html');

--- a/test/test-post-order.js
+++ b/test/test-post-order.js
@@ -10,7 +10,7 @@ suite('Test post order traversal', function() {
       }
     };
 
-    return expect(getTreeModulesPostOrder(tree), 'to satisfy', ['a']);
+    return expect(getTreeModulesPostOrder(tree).modules, 'to satisfy', ['a']);
   });
 
   test('should return modules that has no incoming relations', function() {
@@ -25,7 +25,7 @@ suite('Test post order traversal', function() {
       }
     };
 
-    return expect(getTreeModulesPostOrder(tree), 'to satisfy', ['a', 'b']);
+    return expect(getTreeModulesPostOrder(tree).modules, 'to satisfy', ['a', 'b']);
   });
 
   test('should resolve module names based on depMap', function() {
@@ -42,7 +42,7 @@ suite('Test post order traversal', function() {
       }
     };
 
-    return expect(getTreeModulesPostOrder(tree), 'to satisfy', ['b', 'a']);
+    return expect(getTreeModulesPostOrder(tree).modules, 'to satisfy', ['b', 'a']);
   });
 
   test('should order modules with dependencies first', function() {
@@ -70,7 +70,7 @@ suite('Test post order traversal', function() {
       }
     };
 
-    return expect(getTreeModulesPostOrder(tree), 'to satisfy', ['c', 'b', 'd', 'a']);
+    return expect(getTreeModulesPostOrder(tree).modules, 'to satisfy', ['c', 'b', 'd', 'a']);
   });
 
   test('should order graph entries alphabetically', function() {
@@ -97,7 +97,7 @@ suite('Test post order traversal', function() {
       }
     };
 
-    return expect(getTreeModulesPostOrder(tree), 'to satisfy', ['c', 'b', 'a', 'd']);
+    return expect(getTreeModulesPostOrder(tree).modules, 'to satisfy', ['c', 'b', 'a', 'd']);
   });
 
   test('should override alphabetical graph entry order with entryPoints array', function() {
@@ -124,7 +124,7 @@ suite('Test post order traversal', function() {
       }
     };
 
-    return expect(getTreeModulesPostOrder(tree, ['d', 'a']), 'to satisfy', ['d', 'c', 'b', 'a']);
+    return expect(getTreeModulesPostOrder(tree, ['d', 'a']).modules, 'to satisfy', ['d', 'c', 'b', 'a']);
   });
 
   test('should include entry points not present in given entryPoints order, in alphabetical order', function() {
@@ -155,6 +155,6 @@ suite('Test post order traversal', function() {
       }
     };
 
-    return expect(getTreeModulesPostOrder(tree, ['d']), 'to satisfy', ['d', 'c', 'b', 'a', 'e']);
+    return expect(getTreeModulesPostOrder(tree, ['d']).modules, 'to satisfy', ['d', 'c', 'b', 'a', 'e']);
   });
 });

--- a/test/test-post-order.js
+++ b/test/test-post-order.js
@@ -1,0 +1,160 @@
+var expect = require('unexpected');
+var getTreeModulesPostOrder = require('../lib/utils').getTreeModulesPostOrder;
+
+suite('Test post order traversal', function() {
+  test('should return single module that has no incoming relation', function() {
+    var tree = {
+      'a': {
+        deps: [],
+        depMap: {}
+      }
+    };
+
+    return expect(getTreeModulesPostOrder(tree), 'to satisfy', ['a']);
+  });
+
+  test('should return modules that has no incoming relations', function() {
+    var tree = {
+      'a': {
+        deps: [],
+        depMap: {}
+      },
+      'b': {
+        deps: [],
+        depMap: {}
+      }
+    };
+
+    return expect(getTreeModulesPostOrder(tree), 'to satisfy', ['a', 'b']);
+  });
+
+  test('should resolve module names based on depMap', function() {
+    var tree = {
+      'a': {
+        deps: ['foo'],
+        depMap: {
+          'foo': 'b'
+        }
+      },
+      'b': {
+        deps: [],
+        depMap: {}
+      }
+    };
+
+    return expect(getTreeModulesPostOrder(tree), 'to satisfy', ['b', 'a']);
+  });
+
+  test('should order modules with dependencies first', function() {
+    var tree = {
+      'a': {
+        deps: ['b', 'd'],
+        depMap: {
+          'b': 'b',
+          'd': 'd'
+        }
+      },
+      'b': {
+        deps: ['c'],
+        depMap: {
+          'c': 'c'
+        }
+      },
+      'c': {
+        deps: [],
+        depMap: {}
+      },
+      'd': {
+        deps: [],
+        depMap: {}
+      }
+    };
+
+    return expect(getTreeModulesPostOrder(tree), 'to satisfy', ['c', 'b', 'd', 'a']);
+  });
+
+  test('should order graph entries alphabetically', function() {
+    var tree = {
+      'a': {
+        deps: ['b'],
+        depMap: {
+          'b': 'b'
+        }
+      },
+      'b': {
+        deps: ['c'],
+        depMap: {
+          'c': 'c'
+        }
+      },
+      'c': {
+        deps: [],
+        depMap: {}
+      },
+      'd': {
+        deps: [],
+        depMap: {}
+      }
+    };
+
+    return expect(getTreeModulesPostOrder(tree), 'to satisfy', ['c', 'b', 'a', 'd']);
+  });
+
+  test('should override alphabetical graph entry order with entryPoints array', function() {
+    var tree = {
+      'a': {
+        deps: ['b'],
+        depMap: {
+          'b': 'b'
+        }
+      },
+      'b': {
+        deps: ['c'],
+        depMap: {
+          'c': 'c'
+        }
+      },
+      'c': {
+        deps: [],
+        depMap: {}
+      },
+      'd': {
+        deps: [],
+        depMap: {}
+      }
+    };
+
+    return expect(getTreeModulesPostOrder(tree, ['d', 'a']), 'to satisfy', ['d', 'c', 'b', 'a']);
+  });
+
+  test('should include entry points not present in given entryPoints order, in alphabetical order', function() {
+    var tree = {
+      'a': {
+        deps: ['b'],
+        depMap: {
+          'b': 'b'
+        }
+      },
+      'b': {
+        deps: ['c'],
+        depMap: {
+          'c': 'c'
+        }
+      },
+      'c': {
+        deps: [],
+        depMap: {}
+      },
+      'd': {
+        deps: [],
+        depMap: {}
+      },
+      'e': {
+        deps: [],
+        depMap: {}
+      }
+    };
+
+    return expect(getTreeModulesPostOrder(tree, ['d']), 'to satisfy', ['d', 'c', 'b', 'a', 'e']);
+  });
+});

--- a/test/test-post-order.js
+++ b/test/test-post-order.js
@@ -1,5 +1,5 @@
 var expect = require('unexpected');
-var getTreeModulesPostOrder = require('../lib/utils').getTreeModulesPostOrder;
+var getTreeModulesPostOrder = require('../lib/trace').getTreeModulesPostOrder;
 
 suite('Test post order traversal', function() {
   test('should return single module that has no incoming relation', function() {


### PR DESCRIPTION
Now that nodejs v4 is out nodejs developers are combining es6 with commonjs modules.
The option `cjs-to-es5` let traceur transpiles that code into es5.

This is useful for:
- minification as uglify-js only supports es5
- supporting other browsers than Chrome.