### PR TITLE
Add missing saveForReset parameter

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -155,7 +155,7 @@ function executeConfigFile(saveForReset, ignoreBaseURL, source) {
   var curSystem = global.System;
   var configSystem = global.System = {
     config: function(cfg) {
-      builder.config(cfg, ignoreBaseURL);
+      builder.config(cfg, saveForReset, ignoreBaseURL);
     }
   };
   // jshint evil:true


### PR DESCRIPTION
saveForReset was not beign passed from executeConfigFile to builder.config. This was causing build.config to work improperly.