### PR TITLE
Use stable name mangling for deterministic builds

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -85,7 +85,6 @@ function minify(output, fileName, mangle, globalDefs) {
     warnings: false
   }));
   ast.figure_out_scope();
-  ast.compute_char_frequency();
   if (mangle !== false) {
     ast.mangle_names({
       except: ['require']


### PR DESCRIPTION
When using the SystemJS builder with enabled minify option builds seem 
to be non-deterministic. Compiling one and the same source results in 
different results which makes computing checksums (and using them as a
cache buster) for those files useless.

The problem seems to be caused by UglifyJS's compute_char_frequency 
method which leads to unstable name mangling (at least in some cases). 
Removing that method from the builder has fixed that problem 
immediately.

The official Grunt Uglify task for instance disabled that method for 
the same reason. 
See: https://github.com/gruntjs/grunt-contrib-uglify/blob/master/tasks/lib/uglify.js#L137