### PR TITLE
Builder invalidation API

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -44,6 +44,62 @@ function Builder(baseURL, cfg) {
     this.loadConfigSync(cfg, true, !!baseURL);
 }
 
+// invalidate the cache for a given module name
+// accepts wildcards (*) which are taken to be deep-matching
+Builder.prototype.invalidate = function(invalidationModuleName) {
+  var loader = this.loader;
+
+  var invalidated = [];
+
+  // invalidation happens in normalized-space
+  invalidationModuleName = loader.normalizeSync(invalidationModuleName);
+
+  // wildcard detection and handling
+  var invalidationWildcardIndex = invalidationModuleName.indexOf('*');
+  if (invalidationModuleName.lastIndexOf('*') != invalidationWildcardIndex)
+    throw new TypeError('Only a single wildcard supported for invalidation.');
+
+  if (invalidationWildcardIndex != -1) {
+    var wildcardLHS = invalidationModuleName.substr(0, invalidationWildcardIndex);
+    var wildcardRHS = invalidationModuleName.substr(invalidationWildcardIndex + 1);
+  }
+
+  function matchesInvalidation(moduleName) {
+    if (moduleName == invalidationModuleName)
+      return true;
+
+    if (invalidationWildcardIndex == -1)
+      return false;
+
+    return moduleName.substr(0, invalidationWildcardIndex) == wildcardLHS 
+        && moduleName.substr(moduleName.length - wildcardRHS.length) == wildcardRHS;
+  }
+
+  // clear the given path from the trace cache
+  var traceCache = this.cache.trace;
+  Object.keys(traceCache).forEach(function(canonical) {
+    var moduleName = loader.normalizeSync(canonical);
+    if (matchesInvalidation(moduleName)) {
+      invalidated.push(moduleName);
+      traceCache[canonical] = undefined;
+    }
+  });
+
+  // clear the given path from the pluginLoader registry
+  var pluginLoader = loader.pluginLoader;
+  Object.keys(pluginLoader._loader.modules).forEach(function(moduleName) {
+    if (matchesInvalidation(moduleName)) {
+      invalidated.push(moduleName);
+      pluginLoader.delete(moduleName);
+    }
+  });
+
+  // we leave the compile cache in-tact as it is hashed
+
+  // return array of invalidated canonicals
+  return invalidated;
+};
+
 Builder.prototype.reset = function(baseLoader) {
   baseLoader = baseLoader || this.loader || System;
 
@@ -115,20 +171,6 @@ Builder.prototype.reset = function(baseLoader) {
     if (pkgConditional)
       normalized = normalized.substr(0, normalized.length - 1) + pkgConditional;
     return normalized;
-  };
-
-  // add a local fetch cache to the loader
-  // useful for plugin duplications of hooks
-  var fetchCache = {};
-  var loaderFetch = loader.fetch;
-  loader.fetch = pluginLoader.fetch = function(load) {
-    if (fetchCache[load.address])
-      return fetchCache[load.address];
-
-    return Promise.resolve(loaderFetch.call(this, load)).then(function(source) {
-      fetchCache[load.address] = source;
-      return source;
-    });
   };
 
   if (this.resetConfig)

--- a/test/test-build-cache.js
+++ b/test/test-build-cache.js
@@ -76,6 +76,20 @@ suite('Test compiler cache', function() {
     return builder.bundle('simple.js').then(function(output) {
       expect(output.source).to.contain('fake cache');
     });
+  });
 
+  test('Cache invalidation', function() {
+    var cacheObj = {
+      trace: {
+        'simple.js': {},
+        'another/path.js': {}
+      }
+    };
+
+    builder.reset();
+    builder.setCache(cacheObj);
+
+    var invalidated = builder.invalidate('*');
+    assert.deepEqual(invalidated, [System.normalizeSync('simple.js'), System.normalizeSync('another/path.js')]);
   });
 });

--- a/test/test-build-cache.js
+++ b/test/test-build-cache.js
@@ -91,5 +91,21 @@ suite('Test compiler cache', function() {
 
     var invalidated = builder.invalidate('*');
     assert.deepEqual(invalidated, [System.normalizeSync('simple.js'), System.normalizeSync('another/path.js')]);
+
+    cacheObj = {
+      trace: {
+        'simple.js': {},
+        'new/path.js': {},
+        'deep/wildcard/test.js': {}
+      }
+    };
+
+    builder.setCache(cacheObj);
+
+    invalidated = builder.invalidate('new/path.js');
+    assert.deepEqual(invalidated, [System.normalizeSync('new/path.js')]);
+
+    invalidated = builder.invalidate('deep/*.js');
+    assert.deepEqual(invalidated, [System.normalizeSync('deep/wildcard/test.js')]);
   });
 });


### PR DESCRIPTION
`builder.invalidate('path')` or `builder.invalidate('some/wildcard/*')`

Invalidation works in full module name space identical to the loader.

Invalidation is synchronous and returns the array of fully-normalized names invalidated - eg `['file:///path/to/project/x.js']`.

Inspired by the work of @jackfranklin in https://github.com/jackfranklin/jspm-dev-builder/blob/master/index.js!