### PR TITLE
Add fetch hook into tracer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,28 @@ builder.config({
 });
 ```
 
+### Overriding Fetch
+
+The framework fetch function can be overridden in order to provide the source for a file manually. This is useful if you want to pre-process the source of a file before using the builder.
+
+```javascript
+var mySource = 'import * from foo; var foo = "bar";'; // get source as a string
+builder.bundle('foo.js', {
+  fetch: function (load, fetch) {
+    if (load.name.indexOf('foo.js') !== -1) {
+      return mySource;
+    } else {
+      // fall back to the normal fetch method
+      return fetch(load);
+    }
+  }
+});
+```
+
+The `load` variable describes the file that is trying to be loaded. This is called once for every file that is trying to be fetched, including dependencies.
+
+The `fetch` function should return a string.
+
 ### Bundle Arithmetic
 
 Both `builder.build` and `builder.buildStatic` support bundle arithmetic expressions. This allows for the easy construction of custom bundles.

--- a/lib/arithmetic.js
+++ b/lib/arithmetic.js
@@ -136,7 +136,7 @@ exports.traceExpression = function(builder, expression, traceOpts) {
           return getTreeModuleOperation(builder, op.operator)(curTree, op.moduleName);
         
         // tree . tree
-        return builder.tracer.traceModule(op.moduleName, traceOpts.traceAllConditionals, traceOpts.conditions, traceOpts.traceConditionsOnly)
+        return builder.tracer.traceModule(op.moduleName, traceOpts.traceAllConditionals, traceOpts.conditions, traceOpts.traceConditionsOnly, traceOpts.fetch)
         .then(function(nextTrace) {
           return getTreeOperation(op.operator)(curTree, nextTrace.tree);
         });

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -242,8 +242,7 @@ function processTraceOpts(options, defaults) {
     node: undefined,
     traceAllConditionals: true,
     conditions: {},
-    traceConditionsOnly: false,
-    fetch: undefined
+    traceConditionsOnly: false
   };
 
   extend(opts, defaults);
@@ -409,6 +408,20 @@ Builder.prototype.bundle = function(expressionOrTree, outFile, opts) {
     this.config(opts.config);
 
   var outputOpts = processOutputOpts(opts, { outFile: outFile });
+
+  // override the fetch function if given
+  if (opts) {
+    var loaderFetch = self.loader.fetch;
+    self.fetch = opts.fetch;
+    self.loader.fetch = function (load) {
+      var args = Array.prototype.slice.call(arguments, 0);
+      args.push(function () {
+        return loaderFetch.apply(self.loader, args);
+      });
+
+      return (self.fetch || loaderFetch).apply(self.loader, args);
+    };
+  }
 
   return Promise.resolve()
   .then(function() {

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -415,9 +415,7 @@ Builder.prototype.bundle = function(expressionOrTree, outFile, opts) {
     self.fetch = opts.fetch;
     self.loader.fetch = function (load) {
       var args = Array.prototype.slice.call(arguments, 0);
-      args.push(function () {
-        return loaderFetch.apply(self.loader, args);
-      });
+      args.push(loaderFetch.bind(self.loader));
 
       var source = (self.fetch || loaderFetch).apply(self.loader, args);
 

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -419,7 +419,14 @@ Builder.prototype.bundle = function(expressionOrTree, outFile, opts) {
         return loaderFetch.apply(self.loader, args);
       });
 
-      return (self.fetch || loaderFetch).apply(self.loader, args);
+      var source = (self.fetch || loaderFetch).apply(self.loader, args);
+
+      if (typeof source === 'undefined') {
+        console.warn('Provided fetch function but did not return source for', load.name);
+        source = '';
+      }
+
+      return source;
     };
   }
 

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -242,7 +242,8 @@ function processTraceOpts(options, defaults) {
     node: undefined,
     traceAllConditionals: true,
     conditions: {},
-    traceConditionsOnly: false
+    traceConditionsOnly: false,
+    fetch: undefined
   };
 
   extend(opts, defaults);

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -23,7 +23,7 @@ function Trace(loader, traceCache) {
  * High-level functions
  */
 var namedRegisterRegEx = /(System\.register(Dynamic)?|define)\(('[^']+'|"[^"]+")/g;
-Trace.prototype.traceModule = function(moduleName, traceAllConditionals, conditionalEnv, conditionsOnly, fetchHook) {
+Trace.prototype.traceModule = function(moduleName, traceAllConditionals, conditionalEnv, conditionsOnly) {
   var loader = this.loader;
 
   var self = this;
@@ -35,7 +35,7 @@ Trace.prototype.traceModule = function(moduleName, traceAllConditionals, conditi
   })
   .then(function(canonicalConditionalEnv) {
     if (!conditionsOnly)
-      return self.getAllLoadRecords(moduleName, traceAllConditionals, canonicalConditionalEnv, undefined, fetchHook);
+      return self.getAllLoadRecords(moduleName, traceAllConditionals, canonicalConditionalEnv, undefined);
     else
       return self.getConditionLoadRecords(moduleName, canonicalConditionalEnv);
   })
@@ -62,7 +62,7 @@ Trace.prototype.traceModule = function(moduleName, traceAllConditionals, conditi
  * Low-level functions
  */
 // runs the pipeline hooks, returning the load record for a module
-Trace.prototype.getLoadRecord = function(canonical, fetchHook) {
+Trace.prototype.getLoadRecord = function(canonical) {
   var loader = this.loader;
   var loads = this.loads;
 
@@ -280,10 +280,7 @@ Trace.prototype.getLoadRecord = function(canonical, fetchHook) {
       var originalSource;
 
       curHook = 'fetch';
-      return Promise.resolve(
-        fetchHook ?
-          fetchHook({ name: normalized, metadata: load.metadata, address: address })
-          : loader.fetch({ name: normalized, metadata: load.metadata, address: address }))
+      return Promise.resolve(loader.fetch({ name: normalized, metadata: load.metadata, address: address }))
       .then(function(source) {
         originalSource = source;
         curHook = 'translate';
@@ -373,7 +370,7 @@ Trace.prototype.getLoadRecord = function(canonical, fetchHook) {
  *
  */
 var systemModules = ['@empty', '@system-env', '@@amd-helpers', '@@global-helpers'];
-Trace.prototype.getAllLoadRecords = function(canonical, traceAllConditionals, canonicalConditionalEnv, curLoads, fetchHook) {
+Trace.prototype.getAllLoadRecords = function(canonical, traceAllConditionals, canonicalConditionalEnv, curLoads) {
   var loader = this.loader;
 
   curLoads = curLoads || {};
@@ -382,7 +379,7 @@ Trace.prototype.getAllLoadRecords = function(canonical, traceAllConditionals, ca
     return curLoads;
 
   var self = this;
-  return this.getLoadRecord(canonical, fetchHook)
+  return this.getLoadRecord(canonical)
   .then(function(load) {
     // conditionals, build: false and system modules are falsy loads in the trace trees
     // (that is, part of depcache, but not built)

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -23,7 +23,7 @@ function Trace(loader, traceCache) {
  * High-level functions
  */
 var namedRegisterRegEx = /(System\.register(Dynamic)?|define)\(('[^']+'|"[^"]+")/g;
-Trace.prototype.traceModule = function(moduleName, traceAllConditionals, conditionalEnv, conditionsOnly) {
+Trace.prototype.traceModule = function(moduleName, traceAllConditionals, conditionalEnv, conditionsOnly, fetchHook) {
   var loader = this.loader;
 
   var self = this;
@@ -35,7 +35,7 @@ Trace.prototype.traceModule = function(moduleName, traceAllConditionals, conditi
   })
   .then(function(canonicalConditionalEnv) {
     if (!conditionsOnly)
-      return self.getAllLoadRecords(moduleName, traceAllConditionals, canonicalConditionalEnv);
+      return self.getAllLoadRecords(moduleName, traceAllConditionals, canonicalConditionalEnv, undefined, fetchHook);
     else
       return self.getConditionLoadRecords(moduleName, canonicalConditionalEnv);
   })
@@ -62,7 +62,7 @@ Trace.prototype.traceModule = function(moduleName, traceAllConditionals, conditi
  * Low-level functions
  */
 // runs the pipeline hooks, returning the load record for a module
-Trace.prototype.getLoadRecord = function(canonical) {
+Trace.prototype.getLoadRecord = function(canonical, fetchHook) {
   var loader = this.loader;
   var loads = this.loads;
 
@@ -280,7 +280,10 @@ Trace.prototype.getLoadRecord = function(canonical) {
       var originalSource;
 
       curHook = 'fetch';
-      return Promise.resolve(loader.fetch({ name: normalized, metadata: load.metadata, address: address }))
+      return Promise.resolve(
+        fetchHook ?
+          fetchHook({ name: normalized, metadata: load.metadata, address: address })
+          : loader.fetch({ name: normalized, metadata: load.metadata, address: address }))
       .then(function(source) {
         originalSource = source;
         curHook = 'translate';
@@ -370,7 +373,7 @@ Trace.prototype.getLoadRecord = function(canonical) {
  *
  */
 var systemModules = ['@empty', '@system-env', '@@amd-helpers', '@@global-helpers'];
-Trace.prototype.getAllLoadRecords = function(canonical, traceAllConditionals, canonicalConditionalEnv, curLoads) {
+Trace.prototype.getAllLoadRecords = function(canonical, traceAllConditionals, canonicalConditionalEnv, curLoads, fetchHook) {
   var loader = this.loader;
 
   curLoads = curLoads || {};
@@ -379,7 +382,7 @@ Trace.prototype.getAllLoadRecords = function(canonical, traceAllConditionals, ca
     return curLoads;
 
   var self = this;
-  return this.getLoadRecord(canonical)
+  return this.getLoadRecord(canonical, fetchHook)
   .then(function(load) {
     // conditionals, build: false and system modules are falsy loads in the trace trees
     // (that is, part of depcache, but not built)

--- a/test/test-build.js
+++ b/test/test-build.js
@@ -43,11 +43,11 @@ function doTests(transpiler) {
     builder.reset();
     builder.config({ transpiler: transpiler });
     return builder.bundle('foo.js', {
-      fetch: function (load, pass) {
+      fetch: function (load, fetch) {
         if (load.name.indexOf('foo.js') !== -1) {
           return fs.readFileSync('test/fixtures/test-tree/amd-1.js', 'utf8');
         } else {
-          return pass();
+          return fetch(load);
         }
       }
     });

--- a/test/test-build.js
+++ b/test/test-build.js
@@ -43,9 +43,11 @@ function doTests(transpiler) {
     builder.reset();
     builder.config({ transpiler: transpiler });
     return builder.bundle('foo.js', {
-      fetch: function (data) {
-        if (data.name.indexOf('foo.js') !== -1) {
+      fetch: function (load, pass) {
+        if (load.name.indexOf('foo.js') !== -1) {
           return fs.readFileSync('test/fixtures/test-tree/amd-1.js', 'utf8');
+        } else {
+          return pass();
         }
       }
     });

--- a/test/test-build.js
+++ b/test/test-build.js
@@ -39,6 +39,18 @@ function doTests(transpiler) {
     });
   });
 
+  test('Static string build', function () {
+    builder.reset();
+    builder.config({ transpiler: transpiler });
+    return builder.bundle('foo.js', {
+      fetch: function (data) {
+        if (data.name.indexOf('foo.js') !== -1) {
+          return fs.readFileSync('test/fixtures/test-tree/amd-1.js', 'utf8');
+        }
+      }
+    });
+  });
+
   test('Multi-format tree build', function() {
     builder.reset();
     builder.config({ transpiler: transpiler });


### PR DESCRIPTION
This is a first draft on how to hook static string data. This would allow you to build the string source of a file yourself, then pass it into the builder to resolve dependencies. Example:

```javascript
builder.build('foo.js', 'bar.js', {
  fetch: function (data) {
    if (data.name.indexOf('foo.js') !== -1) { return 'var bar = 2;'; }
  }
});
```

Fixes #330 