### PR TITLE
Added baseURL and clone of global.System.map in builder.js / executeConfigFile

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -251,7 +251,9 @@ function executeConfigFile(saveForReset, ignoreBaseURL, source) {
   var configSystem = global.System = {
     config: function(cfg) {
       builder.config(cfg, ignoreBaseURL);
-    }
+    },
+    baseURL: curSystem.baseURL,
+    map: extend({}, curSystem.map)
   };
   // jshint evil:true
   new Function(source.toString()).call(global);


### PR DESCRIPTION
Added baseURL and clone of global.System.map to configSystem which is necessary to support access to normalized map paths in further adding mapped paths via additional config loading during the build process. In executeConfigFile the global.System is temporarily rewritten to only expose the config method. This pull request adds `baseURL` and a clone of `global.System.map`.

This allows the ability to create additional mapped paths which access the current normalized paths for dependencies handled by JSPM / SystemJS. An example of an additional config file (`config-app-paths.js`) in my framework TyphonJS which uses this change is:

```
/**
 * Loads mapped paths for TyphonJS in the browser and via Gulp / Node.js allowing normalized
 * dependencies to be used in defining further mapped paths.
 */
var System = System || global.System;

// Debug for testing
console.log('Config-App-Paths - 0 - System.baseURL: ' +System.baseURL);
console.log('Config-App-Paths - 1 - System.map: ' +JSON.stringify(System.map));

var pathParseCore = System.map['typhon-core-parse'];
var pathParsePremium = System.map['typhon-premium-parse'];

System.config(
{
   map:
   {
      'appconfig': 'config/production-config.js',
      ...
      'typhonUser': pathParsePremium +'/src/control/user/TyphonUser.js',
      'typhonUserCollection': pathParseCore +'/src/collections/ParseUsers.js',
   }
});
```

The Gulp task to kick off SystemJS Builder looks like this:
```
   var builder = new jspm.Builder('./config.js');

   builder.loadConfig('./config/config-app-paths.js').then(function()
   {
      ...
   }
```

It should be noted that when running in the browser the full System instance is available. During the build process this is not available therefore adding a copy of baseURL and map is rather useful. 

Adding this change to Builder also resolves my feature request for uninstalling silent:
https://github.com/jspm/jspm-cli/issues/1220