### PR TITLE
Enabled full System Loader support in executeConfigFile

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -246,16 +246,28 @@ function executeConfigFile(saveForReset, ignoreBaseURL, source) {
   if (saveForReset)
     this.resetConfig = source;
 
-  var builder = this;
-  var curSystem = global.System;
-  var configSystem = global.System = {
-    config: function(cfg) {
-      builder.config(cfg, ignoreBaseURL);
+  var System = this.loader;
+
+  // Save existing System.config function.
+  var systemConfigFunc = System.config;
+
+  // Assign a new temporary function which filters the config data; see `Builder.prototype.config`.
+  System.config = function(config) {
+    var cfg = {};
+    for (var p in config) {
+      if (ignoreBaseURL && p == 'baseURL' || p == 'bundles' || p == 'depCache')
+        continue;
+      cfg[p] = config[p];
     }
+    // Invoke existing loader config function.
+    systemConfigFunc(cfg); 
   };
+
   // jshint evil:true
   new Function(source.toString()).call(global);
-  global.System = curSystem;
+
+  // Assign back to System.config the original saved function.
+  System.config = systemConfigFunc;
 }
 
 Builder.prototype.loadConfig = function(configFile, saveForReset, ignoreBaseURL) {


### PR DESCRIPTION
Enabled full System Loader support in `executeConfigFile` in `builder.js`. This allows multiple System.config invocations to have full access to the System Loader API. The use case for this commit is to be able to load additional config files which add additional used defined mapped paths that incorporate existing normalized paths from loaded package dependencies.

As requested in #377 this pull request exposes the entire System Loader API to config loading in the Builder API. In particular the functions `loadConfig` & `loadConfigSync` invokes `executeConfigFile`.

Please see #377 for full use case description. This PR supersedes both #377 and #378 