### PR TITLE
Add use strict checking to cjs bundles.

### DIFF
--- a/compilers/cjs.js
+++ b/compilers/cjs.js
@@ -3,6 +3,7 @@ var url = require('url');
 var traceur = require('traceur');
 var ParseTreeTransformer = traceur.get('codegeneration/ParseTreeTransformer.js').ParseTreeTransformer;
 var Script = traceur.get('syntax/trees/ParseTrees.js').Script;
+var FunctionBody = traceur.get('syntax/trees/ParseTrees.js').FunctionBody;
 var parseStatements = traceur.get('codegeneration/PlaceholderParser.js').parseStatements;
 var parseExpression = traceur.get('codegeneration/PlaceholderParser.js').parseExpression;
 var STRING = traceur.get('syntax/TokenType.js').STRING;
@@ -11,6 +12,8 @@ var LiteralToken = traceur.get('syntax/LiteralToken.js').LiteralToken;
 var IdentifierExpression = traceur.get('syntax/trees/ParseTrees.js').IdentifierExpression;
 var IdentifierToken = traceur.get('syntax/IdentifierToken.js').IdentifierToken;
 var BindingIdentifier = traceur.get('syntax/trees/ParseTrees.js').BindingIdentifier;
+var hasUseStrict = traceur.get('semantics/util.js').hasUseStrict;
+var createUseStrictDirective = traceur.get('codegeneration/ParseTreeFactory.js').createUseStrictDirective;
 
 // remap require() statements
 function CJSRequireTransformer(requireName, map, mappedRequireName) {
@@ -87,18 +90,6 @@ CJSRegisterTransformer.prototype.transformScript = function(tree) {
   var scriptItemList = tree.scriptItemList;
   var nl = '\n    ';
 
-  var useStrict = '';
-  for (var i = 0; i < scriptItemList.length; i++) {
-    // Check to see if the first code source location contains "use strict"
-    if (scriptItemList[i].
-        location.
-        start.
-        source.
-        contents.match(/^['"]use strict['"]/gi)) {
-      useStrict = '"use strict";\n';
-    }
-  }
-
   if (this.usesFilePaths)
     scriptItemList = parseStatements([
       "var __filename = module.id, __dirname = module.id.split('/').splice(0, module.id.split('/').length - 1).join('/');"
@@ -117,10 +108,15 @@ CJSRegisterTransformer.prototype.transformScript = function(tree) {
     globalExpression += ';';
   }
 
-  scriptItemList = parseStatements([
-    useStrict + globalExpression + nl
+  var useStrict = [];
+  if (hasUseStrict(scriptItemList)) {
+    useStrict = [createUseStrictDirective()];
+  }
+
+  scriptItemList = useStrict.concat(parseStatements([
+    globalExpression + nl
     + 'var global = this, __define = global.define;' + nl + 'global.define = undefined;'
-  ]).concat(scriptItemList).concat(parseStatements([
+  ])).concat(scriptItemList).concat(parseStatements([
     'global.define = __define;' + nl
     + 'return module.exports;'
   ]));

--- a/compilers/cjs.js
+++ b/compilers/cjs.js
@@ -87,6 +87,18 @@ CJSRegisterTransformer.prototype.transformScript = function(tree) {
   var scriptItemList = tree.scriptItemList;
   var nl = '\n    ';
 
+  var useStrict = '';
+  for (var i = 0; i < scriptItemList.length; i++) {
+    // Check to see if the first code source location contains "use strict"
+    if (scriptItemList[i].
+        location.
+        start.
+        source.
+        contents.match(/^['"]use strict['"]/gi)) {
+      useStrict = '"use strict";\n';
+    }
+  }
+
   if (this.usesFilePaths)
     scriptItemList = parseStatements([
       "var __filename = module.id, __dirname = module.id.split('/').splice(0, module.id.split('/').length - 1).join('/');"
@@ -106,7 +118,7 @@ CJSRegisterTransformer.prototype.transformScript = function(tree) {
   }
 
   scriptItemList = parseStatements([
-    globalExpression + nl
+    useStrict + globalExpression + nl
     + 'var global = this, __define = global.define;' + nl + 'global.define = undefined;'
   ]).concat(scriptItemList).concat(parseStatements([
     'global.define = __define;' + nl

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -64,7 +64,6 @@ function getEncoding(canonical, encodings) {
 
 exports.compileLoad = compileLoad;
 function compileLoad(loader, load, compileOpts, cache) {
-
   // use cached if we have it
   var cached = cache.loads[load.name];
   if (cached && cached.hash == getCompileHash(load, compileOpts))
@@ -264,7 +263,6 @@ function compileTree(loader, tree, compileOpts, outputOpts, cache) {
     });
   })
   .then(function() {
-
     // if any module in the bundle is AMD, add a "bundle" meta to the bundle
     // this can be deprecated if https://github.com/systemjs/builder/issues/264 lands
     if (modules.some(function(name) {

--- a/test/fixtures/test-tree/Buffer.js
+++ b/test/fixtures/test-tree/Buffer.js
@@ -1,1 +1,2 @@
+"use strict";
 module.exports = 'Buffer';


### PR DESCRIPTION
This fixes #387 

The traceur compiler is quite a pain! The output is extremely verbose. As per the comments on the issue I just added a simple use strict check that prints out `"use strict";` on the first line if it passes the check.

This is just a first draft, there is probably some improvement I can make with feedback :smile: 