### PR TITLE
Log error in compileTree.

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -167,7 +167,7 @@ exports.compileTree = compileTree;
 function compileTree(loader, tree, compileOpts, outputOpts, cache) {
   // verify that the tree is a tree
   verifyTree(tree);
-  
+
   var ordered = getTreeModulesReversePreOrder(tree);
 
   // get entrypoints from graph algorithm
@@ -285,6 +285,9 @@ function compileTree(loader, tree, compileOpts, outputOpts, cache) {
       entryPoints: entryPoints,
       assetList: assetList
     };
+  })
+  .catch(function(err) {
+    console.log(err);
   });
 }
 


### PR DESCRIPTION
Issue #391

There is a long chain of Promise in `compileTree` dealing with modules and plugins which also means there is a high chance of things could go wrong here but there is no log or any other information available  when it happens.