### PR TITLE
Two builders calling loadConfig in parallel

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -264,7 +264,7 @@ function executeConfigFile(saveForReset, ignoreBaseURL, source) {
   };
 
   // jshint evil:true
-  new Function(source.toString()).call(global);
+  eval(source.toString());
 
   // Assign back to System.config the original saved function.
   System.config = systemConfigFunc;

--- a/test/test-load-config.js
+++ b/test/test-load-config.js
@@ -1,0 +1,44 @@
+var Builder = require('../index');
+var fs = require('fs');
+var Promise = require('rsvp').Promise;
+
+
+suite('Test builder.loadConfig', function() {
+    
+  test('builder.loadConfig works', function(done) {
+    
+    var configFile = 'test/output/builderConfig.js';
+    var builder = new Builder();
+    fs.writeFileSync(configFile, 'System.config({map: {m: "./m.js"}});');
+    builder.loadConfig(configFile).then(function() {
+      
+      assert.equal(builder.loader.map['m'], './m.js', 'loader map was loaded from config');
+      
+    }).then(done, done);
+    
+  });
+  
+  test('builder.loadConfig does not affect other builders', function(done) {
+  
+    var configFile1 = 'test/output/builder1Config.js';
+    var configFile2 = 'test/output/builder2Config.js';
+    fs.writeFileSync(configFile1, 'System.config({map: {m1: "./m1.js"}});');
+    fs.writeFileSync(configFile2, 'System.config({map: {m2: "./m2.js"}});');
+    
+    var builder1 = new Builder();
+    var builder2 = new Builder();
+    
+    var p1 = builder1.loadConfig(configFile1);
+    var p2 = builder2.loadConfig(configFile2);
+    
+    
+    Promise.all([p1, p2]).then(function() {
+      
+      assert.equal(builder1.loader.map['m1'], './m1.js', 'builder1.loader map was loaded from config');
+      assert.equal(builder2.loader.map['m2'], './m2.js', 'builder2.loader map was loaded from config');
+      
+    }).then(done, done);      
+      
+  });
+
+});


### PR DESCRIPTION
This adds the testcase for two builders calling loadConfig in parallel, to support use case like this:

    var builder1 = new Builder();
    var builder2 = new Builder();

    builder1.loadConfig('config1.js').then(function() { ... });
    builder2.loadConfig('config2.js').then(function() { ... });

The test fails, and the second commit attempts to fix it.

See also #384 that might be related.