### PR TITLE
fixed isLoadFresh accessed non existant loads variable

### DIFF
--- a/lib/trace.js
+++ b/lib/trace.js
@@ -65,7 +65,7 @@ Trace.prototype.traceModule = function(moduleName, traceAllConditionals, conditi
   });
 };
 
-function isLoadFresh(load, loader) {
+function isLoadFresh(load, loader, loads) {
   if (load === undefined)
     return false;
 
@@ -84,7 +84,7 @@ function isLoadFresh(load, loader) {
   // stat to check freshness
   if (load.plugin) {
     var plugin = loads[load.plugin];
-    if (!isLoadFresh(plugin, loader))
+    if (!isLoadFresh(plugin, loader, loads))
       return false;
   }
   try {
@@ -102,7 +102,7 @@ Trace.prototype.getLoadRecord = function(canonical, parentStack) {
   var loader = this.loader;
   var loads = this.loads;
 
-  if (isLoadFresh(loads[canonical], loader))
+  if (isLoadFresh(loads[canonical], loader, loads))
     return Promise.resolve(loads[canonical]);
 
   if (this.tracing[canonical])


### PR DESCRIPTION
In certain cases (plugins) `isLoadFresh` tries to access the `loads` variable, which simply isn't present in the given context.

This PR fixes this issue.