### PR TITLE
Invalidate throws if the cache is empty

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -51,6 +51,10 @@ function Builder(baseURL, cfg) {
 // invalidate the cache for a given module name
 // accepts wildcards (*) which are taken to be deep-matching
 Builder.prototype.invalidate = function(invalidationModuleName) {
+
+  if (Object.keys(this.cache.trace || {}).length === 0)
+    throw new Error('Invalidate was called but the trace cache is empty');
+
   var loader = this.loader;
 
   var invalidated = [];

--- a/test/test-build-cache.js
+++ b/test/test-build-cache.js
@@ -79,6 +79,13 @@ suite('Test compiler cache', function() {
     });
   });
 
+  test('Cache invalidation when the cache is empty', function() {
+    builder.setCache({});
+    expect(function() {
+      builder.invalidate('*');
+    }).to.throw(/Invalidate was called/i);
+  });
+
   test('Cache invalidation', function() {
     var cacheObj = {
       trace: {


### PR DESCRIPTION
@oliverjash and I spent ages debugging an issue only to realise it was our mistake and that the cache wasn't populated.

This PR changes the behaviour of invalidate to throw if the trace cache is empty. I understand that throwing might be controversial, and I'd happily consider swapping for `console.log`.

@guybedford what do you think? I think this could help with debugging.