### PR TITLE
Take into account package-level default extension in getCanonicalName

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -127,11 +127,20 @@ function canonicalizeCondition(loader, conditionModule) {
 function getCanonicalNamePlain(loader, normalized, isPlugin) {
   // now just reverse apply paths rules to get canonical name
   var pathMatch;
+  var defaultExtension = loader.defaultJSExtensions ? 'js' : false;
 
-  // if we are in a package, remove the basePath
+  // if we are in a package, remove the basePath and use its defaultExtension
   var pkgName = getPackage(loader.packages, normalized);
   if (pkgName) {
     var pkg = loader.packages[pkgName];
+    // use defaultExtension from the package
+    if (pkg) {
+      if (pkg.defaultExtension === false) {
+        defaultExtension = false;
+      } else if (pkg.defaultExtension) {
+        defaultExtension = pkg.defaultExtension;
+      }
+    }
 
     // sanitize basePath
     var basePath = pkg.basePath && pkg.basePath != '.' ? pkg.basePath : '';
@@ -151,7 +160,7 @@ function getCanonicalNamePlain(loader, normalized, isPlugin) {
     if (loader.paths[p].indexOf('*') != -1)
       continue;
 
-    var curPath = normalizePath(loader, p, isPlugin);
+    var curPath = normalizePath(loader, p, isPlugin, defaultExtension);
 
     if (normalized === curPath) {
       // always stop on first exact match
@@ -169,7 +178,7 @@ function getCanonicalNamePlain(loader, normalized, isPlugin) {
         continue;
 
       // normalize the output path
-      var curPath = normalizePath(loader, p, isPlugin);
+      var curPath = normalizePath(loader, p, isPlugin, defaultExtension);
 
       // do reverse match
       var wIndex = curPath.indexOf('*');
@@ -213,14 +222,14 @@ function getPackage(packages, name) {
 }
 
 var absURLRegEx = /^[^\/]+:\/\//;
-function normalizePath(loader, path, isPlugin) {
+function normalizePath(loader, path, isPlugin, defaultExtension) {
   var curPath;
   if (loader.paths[path][0] == '.')
     curPath = decodeURI(url.resolve(toFileURL(process.cwd()) + '/', loader.paths[path]));
   else
     curPath = decodeURI(url.resolve(loader.baseURL, loader.paths[path]));
-  if (loader.defaultJSExtensions && !isPlugin && curPath.substr(curPath.length - 3, 3) != '.js')
-    curPath += '.js';
+  if (defaultExtension && !isPlugin && curPath.substr(curPath.length - 3, 3) != '.' + defaultExtension)
+    curPath += '.' + defaultExtension;
   return curPath;
 }
 

--- a/test/fixtures/default-extension-path/lib/main.js
+++ b/test/fixtures/default-extension-path/lib/main.js
@@ -1,0 +1,3 @@
+import { message } from './module.js';
+
+console.log(message);

--- a/test/fixtures/default-extension-path/lib/module.js
+++ b/test/fixtures/default-extension-path/lib/module.js
@@ -1,0 +1,1 @@
+export let message = 'q';

--- a/test/test-default-extension-path.js
+++ b/test/test-default-extension-path.js
@@ -1,0 +1,26 @@
+var Builder = require('../index');
+
+var builder = new Builder('test/fixtures/default-extension-path');
+
+suite('Test path to package with defaultExtension', function(err) {
+  test('path to package with defaultExtension', function() {
+      builder.config({
+          defaultJSExtensions: true,
+          paths: {
+            "test-app*": "lib*"
+          },
+          packages: {
+            "test-app": {
+              "main": "main.js",
+              "format": "esm",
+              "defaultExtension": false
+            }
+          }
+      });
+      
+      return builder.bundle('test-app').then(function(out) {
+          console.dir(out.entryPoints);
+          assert(out.entryPoints.length == 1 && out.entryPoints[0] == 'test-app/main.js');
+      });
+  });
+});


### PR DESCRIPTION
This is an attempt to fix #413

Not sure if it does not break other people setups though - loader.paths is populated from many places I think, the test covers config.paths only.