### PR TITLE
bug fix in register.js

### DIFF
--- a/compilers/register.js
+++ b/compilers/register.js
@@ -71,7 +71,7 @@ RegisterTransformer.prototype.transformCallExpression = function(tree) {
     }
     // System.register(name, deps, declare)
     else {
-      var args = tree.args.concat([]);
+      var args = tree.args.args.concat([]);
       args.splice(2, 1, declare);
       return new CallExpression(tree.location, this.systemOperand, args);
     }


### PR DESCRIPTION
tree.args is an Object and has no method "concat"... tree.args.args is the array we're looking for.