### PR TITLE
fix #436: make require() available to config code 

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -258,7 +258,7 @@ Builder.prototype.clearCache = function() {
   this.setCache({});
 };
 
-function executeConfigFile(saveForReset, ignoreBaseURL, source) {
+function executeConfigFile(saveForReset, ignoreBaseURL, configPath, source) {
   var self = this;
 
   // create a safe loader to give to the config execution
@@ -273,18 +273,24 @@ function executeConfigFile(saveForReset, ignoreBaseURL, source) {
   var context = Object.create(global);
   context.System = configLoader;
   context.global = context.GLOBAL = context.root = context;
-  context.require = require;
+  // make require available too, make it look as if config file was
+  // loaded like a module
+  var Module = require('module');
+  var m = new Module(configPath);
+  m.filename = configPath;
+  m.paths = Module._nodeModulePaths(path.dirname(configPath));
+  context.require = m.require.bind(m);
   require('vm').runInNewContext(source.toString(), context);
 }
 
 Builder.prototype.loadConfig = function(configFile, saveForReset, ignoreBaseURL) {
   return asp(fs.readFile)(configFile)
-  .then(executeConfigFile.bind(this, saveForReset, ignoreBaseURL));
+  .then(executeConfigFile.bind(this, saveForReset, ignoreBaseURL, configFile));
 };
 
 Builder.prototype.loadConfigSync = function(configFile, saveForReset, ignoreBaseURL) {
   var source = fs.readFileSync(configFile);
-  executeConfigFile.call(this, saveForReset, ignoreBaseURL, source);
+  executeConfigFile.call(this, saveForReset, ignoreBaseURL, configFile, source);
 };
 
 // note ignore argument is part of API

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -273,6 +273,7 @@ function executeConfigFile(saveForReset, ignoreBaseURL, source) {
   var context = Object.create(global);
   context.System = configLoader;
   context.global = context.GLOBAL = context.root = context;
+  context.require = require;
   require('vm').runInNewContext(source.toString(), context);
 }
 

--- a/test/test-load-config.js
+++ b/test/test-load-config.js
@@ -71,15 +71,12 @@ suite('Test builder.loadConfig', function() {
   });
   
   test('builder.loadConfig makes require available to config code',  function(done) {
-    global._tmp_channel = {};
     var configFile = 'test/output/builderConfig.js';
     var builder = new Builder();
-    fs.writeFileSync(configFile, 'global._tmp_channel.result = typeof require;');
+    fs.writeFileSync(configFile, 'var m = require("module"); System.config({baseURL:"base"});');
     builder.loadConfig(configFile).then(function() {
-
-      assert.equal(global._tmp_channel.result, 'function', 'typeof require === \'function\'');
-
-      delete global._tmp_channel;
+  
+      assert.match(builder.loader.baseURL, /base\/$/, 'builder baseURL set');
 
     }).then(done, done);
 

--- a/test/test-load-config.js
+++ b/test/test-load-config.js
@@ -69,5 +69,20 @@ suite('Test builder.loadConfig', function() {
     }).then(done, done);
 
   });
+  
+  test('builder.loadConfig makes require available to config code',  function(done) {
+    global._tmp_channel = {};
+    var configFile = 'test/output/builderConfig.js';
+    var builder = new Builder();
+    fs.writeFileSync(configFile, 'global._tmp_channel.result = typeof require;');
+    builder.loadConfig(configFile).then(function() {
+
+      assert.equal(global._tmp_channel.result, 'function', 'typeof require === \'function\'');
+
+      delete global._tmp_channel;
+
+    }).then(done, done);
+
+  });
 
 });

--- a/test/test-load-config.js
+++ b/test/test-load-config.js
@@ -75,7 +75,7 @@ suite('Test builder.loadConfig', function() {
     var builder = new Builder();
     fs.writeFileSync(configFile, 'var m = require("module"); System.config({baseURL:"base"});');
     builder.loadConfig(configFile).then(function() {
-  
+
       assert.match(builder.loader.baseURL, /base\/$/, 'builder baseURL set');
 
     }).then(done, done);


### PR DESCRIPTION
another tweak to executeConfigFile

require requires special handling because it's not accessible as global.require - "require isn't actually a global but rather local to each module" as they say at https://nodejs.org/api/globals.html#globals_require

well it will belong to global in the config file execution context because I see no other way around it.