### PR TITLE
Fix Trace getLoadRecord error recovery

### DIFF
--- a/lib/trace.js
+++ b/lib/trace.js
@@ -35,7 +35,7 @@ Trace.prototype.traceModule = function(moduleName, traceAllConditionals, conditi
   var loader = this.loader;
 
   var self = this;
-  
+
   return Promise.resolve(loader.normalize(moduleName))
   .then(function(_moduleName) {
     moduleName = getCanonicalName(loader, _moduleName);
@@ -78,7 +78,7 @@ function isLoadFresh(load, loader, loads) {
 
   if (load.fresh)
     return true;
-  
+
   if (load.conditional)
     return false;
 
@@ -111,6 +111,7 @@ Trace.prototype.getLoadRecord = function(canonical, parentStack) {
 
   var self = this;
   var isPackageConditional = canonical.indexOf('#:') != -1;
+
   return this.tracing[canonical] = Promise.resolve(loader.normalize(canonical))
   .then(function(normalized) {
     // modules already set in the registry are system modules
@@ -156,7 +157,7 @@ Trace.prototype.getLoadRecord = function(canonical, parentStack) {
 
       // effective analog of the same function in SystemJS packages.js
       // to work out the path with defaultExtension added.
-      // we cheat here and use normalizeSync to apply the right checks, while 
+      // we cheat here and use normalizeSync to apply the right checks, while
       // skipping any map entry by temporarily removing it.
       function toPackagePath(subPath) {
         var pkgMap = pkg.map;
@@ -169,7 +170,7 @@ Trace.prototype.getLoadRecord = function(canonical, parentStack) {
       var envMap = pkg.map['./' + subPath];
       var metadata = {};
       var fallback;
-      
+
       // resolve the fallback
       return Promise.resolve()
       .then(function() {
@@ -412,18 +413,21 @@ Trace.prototype.getLoadRecord = function(canonical, parentStack) {
   .then(function(load) {
     self.tracing[canonical] = undefined;
     return loads[canonical] = load;
+  }).catch(function (error) {
+    self.tracing[canonical] = undefined;
+    throw error;
   });
 };
 
 /*
  * Returns the full trace tree of a module
- * 
+ *
  * - traceAllConditionals indicates if conditional boundaries should be traversed during the trace.
  * - conditionalEnv represents the conditional tracing environment module values to impose on the trace
  *   forcing traces for traceAllConditionals false, and skipping traces for traceAllConditionals true.
- * 
+ *
  * conditionalEnv provides canonical condition tracing rules of the form:
- * 
+ *
  *  {
  *    'some/interpolation|value': true, // include ALL variations
  *    'another/interpolation|value': false, // include NONE
@@ -540,7 +544,7 @@ Trace.prototype.inlineConditions = function(tree, conditionalEnv) {
   return toCanonicalConditionalEnv.call(this, conditionalEnv)
   .then(function(canonicalConditionalEnv) {
     var inconsistencyErrorMsg = 'For static condition inlining only an exact environment resolution can be built, pending https://github.com/systemjs/builder/issues/311.';
-    
+
     // ensure we have no condition conflicts
     for (var c in conditionalEnv) {
       var val = conditionalEnv[c];


### PR DESCRIPTION
If the getLoadRecord returned promised rejected (like when transpiler exception from syntax error in the module)
the reference to that (rejected)promise kept cached in self.tracing
and further calls to getLoadRecored for that module returned the promise cached in self.tracing

That's breaks continuous builds (tools like jspm-dev-builder)  

fixes jackfranklin/jspm-dev-builder#15
fixes jackfranklin/jspm-dev-builder#11
fixes #433 