### PR TITLE
Add list of all valid builder options

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,28 @@ Promise.all([builder.trace('app/first.js'), builder.trace('app/second.js')])
 });
 ```
 
+#### Options
+
+A full list of options and their corresponding defaults is provided below:
+
+```javascript
+entryPoints: [],
+normalize: true,
+anonymous: false,
+systemGlobal: 'System',
+buildConfig: false,
+inlinePlugins: true,
+static: false,
+encodeNames: undefined,
+sourceMaps: false,
+lowResSourceMaps: false,
+runtime: false,
+format: 'global',
+globalDeps: {},
+globalName: null,
+minify: false
+```
+
 License
 ---
 


### PR DESCRIPTION
I know that some of these options (most?) are scattered throughout the ReadMe, but it's quite common to see a full list of configuration options when interacting with third-party tools.

I'm constantly digging into builder's source to look for these options. Plus, it would be nice to be able to link directly to all possible options inside of my Gulp task.

This could probably be cleaned up a lot and/or turned into more valid documentation. If you think it's worth doing that instead, feel free to reject this and I'll open an issue.