### PR TITLE
remove hardcoded traceur version in utils.js

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,8 +2,9 @@ var path = require('path');
 var url = require('url');
 
 exports.traceurGet = function(module) {
-  require('traceur');
-  return $traceurRuntime.ModuleStore.get('traceur@0.0.95/src/' + module);
+  var traceur = require('traceur');
+  var traceurVersion = new traceur.loader.NodeTraceurLoader().version;
+  return $traceurRuntime.ModuleStore.get('traceur@' + traceurVersion + '/src/' + module);
 };
 
 exports.extend = extend;


### PR DESCRIPTION
Not sure what the long-term plan is, but traceur main branch is at 0.96 already, so this would need to be updated one way or another