### PR TITLE
Eval config files and expose Builder instance as both `SystemJS` and `System`

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -282,7 +282,7 @@ function executeConfigFile(saveForReset, ignoreBaseURL, configPath, source) {
   // only substitute local copy of System
   // and prevent that code from adding anything to the real global 
   var context = Object.create(global);
-  context.System = configLoader;
+  context.SystemJS = context.System = configLoader;
   context.global = context.GLOBAL = context.root = context;
   // make require available too, make it look as if config file was
   // loaded like a module


### PR DESCRIPTION
Yesterday I noticed that the config file reading part must have beend changed in recent versions, because after updating to the latest release, neither my "old" (created early november or so) config files nor those auto-generated by JSPM (__even in latest 0.17beta__) seem to be apply. This stems from arbitrarily different naming convention used for the global SystemJS/Builder instances.

JSPM is still using `SystemJS` but since a recent commit (f436a92a5e5ebba6326cc64b07026086adb01ab2) configuration files are evaluated in an isolated sandbox context where the builder isntance is only exposed as global `System`. In order to stay compatible with (older) configuration files generated by JSPM I added an alias named `SystemJS`.