### PR TITLE
Fixes #480 fetch override for `builder.buildStatic`

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -577,6 +577,10 @@ Builder.prototype.buildStatic = function(expressionOrTree, outFile, opts) {
   var traceOpts = processTraceOpts(opts, { tracePackageConfig: false });
   var compileOpts = processCompileOpts(opts, { static: true });
   var inlineMap;
+
+  // override the fetch function if given
+  if (opts && opts.fetch)
+    this.fetch = opts.fetch;
   
   return Promise.resolve()
   .then(function() {

--- a/test/test-build-cache.js
+++ b/test/test-build-cache.js
@@ -208,6 +208,19 @@ suite('Test compiler cache', function() {
     });
   });
 
+  test('Static build, fetch override', function () {
+    var builder = new Builder('test/fixtures/test-tree');
+    return builder.buildStatic('foo.js', {
+      fetch: function (load, fetch) {
+        if (load.name.indexOf('foo.js') !== -1) {
+          return fs.readFileSync('test/fixtures/test-tree/cjs.js', 'utf8');
+        } else {
+          return fetch(load);
+        }
+      }
+    });
+  });
+
   test('Static string build', function () {
     var builder = new Builder('test/fixtures/test-tree');
     return builder.bundle('foo.js', {


### PR DESCRIPTION
Fixes #480 enabling fetch overrides for `builder.buildStatic`.