### PR TITLE
Fix for Builder Issue #470

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -63,25 +63,36 @@ function toFileURL(path) {
   return 'file://' + (isWin ? '/' : '') + path.replace(/\\/g, '/');
 }
 
-exports.getAlias = getAlias
+exports.getAlias = getAlias;
 function getAlias(loader, canonicalName) {
   var pluginIndex = loader.pluginFirst ? canonicalName.indexOf('!') : canonicalName.lastIndexOf('!');
+
   if (pluginIndex != -1)
     return getAlias(loader, canonicalName.substr(0, pluginIndex)) + '!' + getAlias(loader, canonicalName.substr(pluginIndex + 1));
 
   if (canonicalName.match(/\#[\:\{\?]/))
-    throw new Error('Unable to alias the conditional dependency "' + canonicalName + '".');
+    throw new Error('Get alias not implemented for conditional name "' + canonicalName + '". Remove the conditional exclusion, or post a SystemJS Builder bug if needed!');
+
+  var canonicalPath;
+
+  if (canonicalName.indexOf('/') >= 0)
+    canonicalPath = canonicalName.substr(canonicalName.indexOf('/'), canonicalName.length);
 
   var bestAlias;
 
   function getBestAlias(mapped) {
     return canonicalName.substr(0, mapped.length) == mapped &&
-        (canonicalName.length == mapped.length || canonicalName[mapped.length] == '/');
+     (canonicalName.length == mapped.length || canonicalName[mapped.length] == '/');
   }
 
   Object.keys(loader.map).forEach(function(alias) {
     if (getBestAlias(loader.map[alias]))
+    {
       bestAlias = alias;
+
+      if (canonicalPath)
+        bestAlias += canonicalPath;
+    }
   });
 
   if (bestAlias)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -71,7 +71,7 @@ function getAlias(loader, canonicalName) {
     return getAlias(loader, canonicalName.substr(0, pluginIndex)) + '!' + getAlias(loader, canonicalName.substr(pluginIndex + 1));
 
   if (canonicalName.match(/\#[\:\{\?]/))
-    throw new Error('Get alias not implemented for conditional name "' + canonicalName + '". Remove the conditional exclusion, or post a SystemJS Builder bug if needed!');
+    throw new Error('Unable to alias the conditional dependency "' + canonicalName + '".');
 
   var canonicalPath;
 


### PR DESCRIPTION
This PR adds support for canonical name + path resolution when a dependency + path is excluded (`build: false`) in an SFX build. 