### PR TITLE
Fix for SystemJS Builder Issue #478

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -365,11 +365,14 @@ function wrapSFXOutputs(loader, tree, outputs, entryPoints, compileOpts, cache) 
   });
 
   var externalDepIds = externalDeps.map(function(dep) {
-    if (compileOpts.format == 'global' || compileOpts.format == 'umd') {
+    if (compileOpts.format == 'global' || compileOpts.format == 'umd' && (compileOpts.globalName ||
+     Object.keys(compileOpts.globalDeps).length > 0)) {
       var alias = getAlias(loader, dep);
       var globalDep = compileOpts.globalDeps[dep] || compileOpts.globalDeps[alias];
       if (!globalDep)
-        throw new TypeError('Global SFX bundle dependency "' + alias + '" must be configured to an environment global via the globalDeps option.');
+        throw new TypeError('Global SFX bundle dependency "' + alias +
+         '" must be configured to an environment global via the globalDeps option.');
+
       globalDeps.push(globalDep);
     }
 


### PR DESCRIPTION
This PR only will check UMD global compile options if globalName or globalDeps are defined as Builder options.