### PR TITLE
Fix for SystemJS Builder Issue #470 adding canonical path resolution.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -85,7 +85,7 @@ function getAlias(loader, canonicalName) {
   });
 
   if (bestAlias)
-    return bestAlias;
+    return bestAlias + canonicalName.substr(loader.map[bestAlias].length);
 
   return canonicalName;
 }


### PR DESCRIPTION
Provides the ability to alias modules + any additional specified path.