### PR TITLE
esm plugins are now correctly transpiled in the legacy path (fixes systemjs/plugin-text#28)

### DIFF
--- a/compilers/esm.js
+++ b/compilers/esm.js
@@ -146,7 +146,7 @@ exports.compile = function(load, opts, loader) {
       lowResolutionSourceMap: opts.lowResSourceMaps
     });
 
-    var tree = load.metadata.parseTree || compiler.parse(load.source, load.path);
+    var tree = load.metadata.parseTree || compiler.parse(source, load.path);
 
     if (opts.normalize) {
       var transformer = new TraceurImportNormalizeTransformer(function(dep) {


### PR DESCRIPTION
the `source` variable was the one that used to be sent through the transpiler, but it seems a later update went back to using load.source...
(hey, don't linters have 'unused variable' detection?)