### PR TITLE
Fixing #559 - runtime error when commonjs module.exports is window.location

### DIFF
--- a/templates/sfx-core-register.js
+++ b/templates/sfx-core-register.js
@@ -139,18 +139,16 @@
     var esModule = {};
     // don't trigger getters/setters in environments that support them
     if (typeof exports == 'object' || typeof exports == 'function') {
+      var hasOwnProperty = exports && exports.hasOwnProperty;
       if (getOwnPropertyDescriptor) {
-        var d;
-        for (var p in exports)
-          if (d = Object.getOwnPropertyDescriptor(exports, p))
-            defineProperty(esModule, p, d);
+        for (var p in exports) {
+          if (!trySilentDefineProperty(esModule, exports, p))
+            setPropertyIfHasOwnProperty(esModule, exports, p, hasOwnProperty);
+        }
       }
       else {
-        var hasOwnProperty = exports && exports.hasOwnProperty;
-        for (var p in exports) {
-          if (!hasOwnProperty || exports.hasOwnProperty(p))
-            esModule[p] = exports[p];
-        }
+        for (var p in exports)
+          setPropertyIfHasOwnProperty(esModule, exports, p, hasOwnProperty);
       }
     }
     esModule['default'] = exports;
@@ -158,6 +156,24 @@
       value: true
     });
     return esModule;
+  }
+
+  function setPropertyIfHasOwnProperty(targetObj, sourceObj, propName, hasOwnProperty) {
+    if (!hasOwnProperty || sourceObj.hasOwnProperty(propName))
+      targetObj[propName] = sourceObj[propName];
+  }
+
+  function trySilentDefineProperty(targetObj, sourceObj, propName) {
+    try {
+      var d;
+      if (d = Object.getOwnPropertyDescriptor(sourceObj, propName))
+        defineProperty(targetObj, propName, d);
+
+      return true;
+    } catch (ex) {
+      // Object.getOwnPropertyDescriptor threw an exception, fall back to normal set property.
+      return false;
+    }
   }
 
   /*


### PR DESCRIPTION
See #559, systemjs/systemjs#1192, and systemjs/systemjs#1193. I literally copied and pasted the code from the systemjs pull request into the two templates here in the builder. I verified locally that my project (that was failing to bootstrap in the browser because of the problem) is now successfully bootstrapping.

Let me know if you'd prefer me to take the minified/built files out of this pull request. Also, I'm not sure what the `.uin.js` files are but I didn't see a way to rebuild those files.