### PR TITLE
Fix: Output minification step breaks SourceMap chain with inlined `sourceContents` #561

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ builder.bundle('myModule.js', 'outfile.js', { sourceMaps: true, lowResSourceMaps
 builder.bundle('myModule.js', 'outfile.js', { minify: true, mangle: false, globalDefs: { DEBUG: false } });
 ```
 
+#### SourceMap Options
+
+* `sourceMaps`, Either boolean value (enable/disable) or string value `'inline'` which will inline the SourceMap data as Base64 data URI right in the generated output file (never use in production). *(Default is `false`)*
+* `sourceMapContents`, Boolean value that determines if original sources shall be directly included in the SourceMap. Using inline source contents generates truely self contained SourceMaps which will not need to load the external original source files during debugging. *(Default is `false`; when using `sourceMaps='inline'` it defaults `true`)*
+
+
 ### In-Memory Builds
 
 Leave out the `outFile` option to run an in-memory build:

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -537,6 +537,9 @@ function processOutputOpts(options, defaults) {
   if (opts.sourceMapContents === undefined)
     opts.sourceMapContents = opts.sourceMaps == 'inline';
 
+  if (opts.sourceMapContents)
+    opts.uglify.sourceMapIncludeSources = true;
+
   return opts;
 }
 

--- a/lib/output.js
+++ b/lib/output.js
@@ -86,11 +86,22 @@ function minify(output, fileName, mangle, uglifyOpts) {
     ast.mangle_names();
 
   var sourceMap;
-  if (output.sourceMap)
+  if (output.sourceMap) {
+    if (typeof output.sourceMap === 'string')
+      output.sourceMap = JSON.parse(output.sourceMap);
+
+    var sourceMapIn = output.sourceMap;
     sourceMap = uglify.SourceMap({
       file: fileName,
-      orig: output.sourceMap
+      orig: sourceMapIn
     });
+
+    if (uglifyOpts.sourceMapIncludeSources && sourceMapIn && Array.isArray(sourceMapIn.sourcesContent)) {
+      sourceMapIn.sourcesContent.forEach(function(content, idx) {
+        sourceMap.get().setSourceContent(sourceMapIn.sources[idx], content);
+      });
+    }
+  }
 
   var outputOptions = uglifyOpts.beautify;
   // keep first comment


### PR DESCRIPTION
Addresses issue #561