### PR TITLE
node.js 6 fixes

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -145,7 +145,7 @@ function inlineSourceMap(source, sourceMap) {
 exports.writeOutputs = function(outputs, baseURL, outputOpts) {
   var outFile = outputOpts.outFile && path.resolve(outputOpts.outFile);
   var basePath = fromFileURL(baseURL);
-  var fileName = path.basename(outFile) || 'output.js';
+  var fileName = (outFile && path.basename(outFile)) || 'output.js';
 
   var output = createOutput(outFile || path.resolve(basePath, fileName), outputs, basePath, outputOpts.sourceMaps, outputOpts.sourceMapContents);
 

--- a/lib/output.js
+++ b/lib/output.js
@@ -79,7 +79,7 @@ function minify(output, fileName, mangle, uglifyOpts) {
     throw new Error(e);
   }
   ast.figure_out_scope();
-  
+
   ast = ast.transform(uglify.Compressor(uglifyOpts.compress));
   ast.figure_out_scope();
   if (mangle !== false)
@@ -126,7 +126,7 @@ function writeOutputFile(outFile, source, sourceMap) {
 
     var sourceMapFileName = path.basename(outFile) + '.map';
     source += '\n//# sourceMappingURL=' + sourceMapFileName;
-    
+
     return asp(fs.writeFile)(path.resolve(outDir, sourceMapFileName), sourceMap);
   })
   .then(function() {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -278,7 +278,7 @@ function isPackageConfig(loader, canonical) {
 
   // generate canonical packageConfigPaths for matching
   if (!configPathCache) {
-    canonicalConfigPaths = loader.packageConfigPaths.map(function(configPath) {
+    canonicalConfigPaths = Object.keys(loader.packageConfigPaths).map(function(configPath) {
       return getCanonicalName(loader, configPath);
     });
     configPathCache = {};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -91,7 +91,7 @@ function getAlias(loader, canonicalName) {
       bestAliasSubpath = '';
       bestAliasLength = alias.split('/').length;
     }
-    else if (canonicalName.substr(0, mapped.length) == mapped && 
+    else if (canonicalName.substr(0, mapped.length) == mapped &&
         (canonicalName.length == mapped.length || canonicalName[mapped.length] == '/')) {
       bestAlias = alias;
       bestAliasSubpath = canonicalName.substr(mapped.length);
@@ -326,5 +326,3 @@ function normalizePath(loader, path, skipExtension) {
   loader.packages = curPackages;
   return normalized;
 }
-
-


### PR DESCRIPTION
The enclosed changes make assetgraph's systemjs-builder tests work with node.js 6. Previously it failed like this: https://travis-ci.org/assetgraph/assetgraph/jobs/126310648

The `configPathCache` thing seems a bit weird to me -- when would an object ever have a `map` method?