### PR TITLE
Single named modules used as anonymous modules in ternaire conditions

### DIFF
--- a/compilers/amd.js
+++ b/compilers/amd.js
@@ -252,7 +252,7 @@ AMDDefineRegisterTransformer.prototype.transformCallExpression = function(tree) 
   */
   var nameAlias = '';
   if (name && this.name && name != this.name)
-    nameAlias = ', define("' + name + '", ["' + this.name + '"], function(m) { return m; })';
+    nameAlias = '&& define("' + name + '", ["' + this.name + '"], function(m) { return m; })';
 
   // write out the anonymous define as named and dep-normalized
   return parseExpression(['define(' + (this.name ? '"' + this.name + '", ' : '') + JSON.stringify(deps) + ', ', ')' + nameAlias + ';'], factoryTree);


### PR DESCRIPTION
I had an issue because the builder produced the following code:
```js
(function() {
var define = $__System.amdDefine;
(function(global, factory) {
  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) : typeof define === 'function' && define.amd ? define("9d", ["exports"], factory) , define("js-data", ["9d"], function(m) {
    return m;
  }) : (factory((global.JSData = global.JSData || {})));
}(this, function(exports) {
```

But it is not valid Javascript, the **comma** between the two `define` couldn't be correctly parsed.

I think it comes from `compilers/amd.js` with the "support for single named modules as doubling as anonymous modules". It produces two `define` separated with a comma, but when this code comes in a ternaire condition, it brokes the file.

So I propose to use `&&` instead of `,` which give the same result but a valid code.