### PR TITLE
Only copying default property of commonjs modules once onto esModule. Fixes jspm#1793

### DIFF
--- a/templates/sfx-core-register.js
+++ b/templates/sfx-core-register.js
@@ -140,13 +140,18 @@
     // don't trigger getters/setters in environments that support them
     if ((typeof exports == 'object' || typeof exports == 'function') && exports !== global) {
       if (getOwnPropertyDescriptor) {
-        for (var p in exports)
+        for (var p in exports) {
+          // The default property is copied to esModule later on
+          if (p === 'default')
+            continue;
           defineOrCopyProperty(esModule, exports, p);
+        }
       }
       else {
         var hasOwnProperty = exports && exports.hasOwnProperty;
         for (var p in exports) {
-          if (hasOwnProperty && !exports.hasOwnProperty(p))
+          // The default property is copied to esModule later on
+          if (p === 'default' || (hasOwnProperty && !exports.hasOwnProperty(p)))
             continue;
           esModule[p] = exports[p];
         }

--- a/templates/sfx-core.js
+++ b/templates/sfx-core.js
@@ -292,13 +292,18 @@
     // don't trigger getters/setters in environments that support them
     if ((typeof exports == 'object' || typeof exports == 'function') && exports !== global) {
       if (getOwnPropertyDescriptor) {
-        for (var p in exports)
+        for (var p in exports) {
+          // The default property is copied to esModule later on
+          if (p === 'default')
+            continue;
           defineOrCopyProperty(esModule, exports, p);
+        }
       }
       else {
         var hasOwnProperty = exports && exports.hasOwnProperty;
         for (var p in exports) {
-          if (hasOwnProperty && !exports.hasOwnProperty(p))
+          // The default property is copied to esModule later on
+          if (p === 'default' || (hasOwnProperty && !exports.hasOwnProperty(p)))
             continue;
           esModule[p] = exports[p];
         }


### PR DESCRIPTION
This fixes jspm/jspm-cli#1793.