### PR TITLE
Fixed  #615 - Compile#getEncoding() should consider npm-scope package

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -43,7 +43,7 @@ function getCompileHash(load, compileOpts) {
 
 function getEncoding(canonical, encodings) {
   // dont encode system modules
-  if (canonical[0] == '@' && canonical != '@dummy-entry-point')
+  if (canonical[0] == '@' && (canonical != '@dummy-entry-point' && canonical.indexOf('/') == 0))
     return canonical;
 
   // return existing encoding if present


### PR DESCRIPTION
Fixed #615 - Compile#getEncoding() should consider npm-scope package 