### PR TITLE
Make builder accessible in plugins

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -121,12 +121,10 @@ Builder.prototype.reset = function(baseLoader) {
   baseLoader = baseLoader || this.loader || System;
 
   var loader = this.loader = new baseLoader.constructor();
-  loader.builder = true;
+  // make builder accessible in plugins
+  loader.builder = this;
   // put the loader in the builder environment
   loader.config({ build: true });
-  
-  // make builder accessible in plugins
-  loader.systemJSBuilder = this;
 
   loader.import = function(name) {
     return Promise.reject(new Error('Unable to import "' + name + '".\nThe incorrect instance of System is being used to System.import.'));

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -124,6 +124,9 @@ Builder.prototype.reset = function(baseLoader) {
   loader.builder = true;
   // put the loader in the builder environment
   loader.config({ build: true });
+  
+  // make builder accessible in plugins
+  loader.systemJSBuilder = this;
 
   loader.import = function(name) {
     return Promise.reject(new Error('Unable to import "' + name + '".\nThe incorrect instance of System is being used to System.import.'));


### PR DESCRIPTION
In some plugins the builder has to be accessible, for instance the WebWorker plugin.