### PR TITLE
demonstrate issue with load.metadata.timestamp not being set

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -176,8 +176,7 @@ Builder.prototype.reset = function(baseLoader) {
   var loaderFetch = loader.fetch;
   loader.fetch = function(load) {
     var self = this;
-    return Promise.resolve((builder.fetch || loaderFetch).call(this, load, function(load) {
-      return Promise.resolve(loaderFetch.call(self, load))
+    return Promise.resolve((builder.fetch || loaderFetch).call(this, load))
       .then(function(source) {
         // calling default fs.readFile fetch -> set timestamp as well for cache invalidation
         return asp(fs.stat)(fromFileURL(load.address))
@@ -190,8 +189,7 @@ Builder.prototype.reset = function(baseLoader) {
             return source;
           throw err;
         });
-      })
-    }));
+      });
   };
 
   // this allows us to normalize package conditionals into package conditionals

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -174,22 +174,28 @@ Builder.prototype.reset = function(baseLoader) {
 
   // allow a custom fetch hook
   var loaderFetch = loader.fetch;
-  loader.fetch = function(load) {
-    var self = this;
-    return Promise.resolve((builder.fetch || loaderFetch).call(this, load))
-      .then(function(source) {
-        // calling default fs.readFile fetch -> set timestamp as well for cache invalidation
-        return asp(fs.stat)(fromFileURL(load.address))
-        .then(function(stats) {
-          load.metadata.timestamp = stats.mtime.getTime();
+  var cachedFetch = function(load) {
+    return Promise.resolve(loaderFetch.call(this, load))
+    .then(function(source) {
+      // calling default fs.readFile fetch -> set timestamp as well for cache invalidation
+      return asp(fs.stat)(fromFileURL(load.address))
+      .then(function(stats) {
+        load.metadata.timestamp = stats.mtime.getTime();
+        return source;
+      }, function(err) {
+        // if the stat fails on a plugin, it may not be linked to the file itself
+        if (err.code == 'ENOENT' && load.metadata.loader)
           return source;
-        }, function(err) {
-          // if the stat fails on a plugin, it may not be linked to the file itself
-          if (err.code == 'ENOENT' && load.metadata.loader)
-            return source;
-          throw err;
-        });
+        throw err;
       });
+    });
+  };
+
+  loader.fetch = function(load) {
+    if (builder.fetch)
+      return Promise.resolve(builder.fetch.call(this, load, cachedFetch));
+    else  
+      return cachedFetch.call(this, load);
   };
 
   // this allows us to normalize package conditionals into package conditionals

--- a/test/test-build-cache.js
+++ b/test/test-build-cache.js
@@ -115,7 +115,7 @@ suite('Test compiler cache', function() {
     var builder = new Builder('test/output');
     fs.writeFileSync('./test/output/timestamp-module.js', source);
     var address = builder.loader.normalizeSync('./test/output/timestamp-module.js');
-    var load = { name: address, address, metadata: {} };
+    var load = { name: address, address: address, metadata: {} };
     return builder.loader.fetch(load)
       .then(function(text) {
          //console.log(JSON.stringify(load));

--- a/test/test-build-cache.js
+++ b/test/test-build-cache.js
@@ -110,6 +110,21 @@ suite('Test compiler cache', function() {
     assert.deepEqual(invalidated, [builder.loader.normalizeSync('deep/wildcard/test.js')]);
   });
 
+  test('builder.loader.fetch sets load.metadata.timestamp', function() {
+    var source = 'export var p = 5;';
+    var builder = new Builder('test/output');
+    fs.writeFileSync('./test/output/timestamp-module.js', source);
+    var address = builder.loader.normalizeSync('./test/output/timestamp-module.js');
+    var load = { name: address, address, metadata: {} };
+    return builder.loader.fetch(load)
+      .then(function(text) {
+         //console.log(JSON.stringify(load));
+         assert(text == source);          // true
+         assert(load.metadata.deps);      // true
+         assert(load.metadata.timestamp); // false
+      })
+  });
+
   test('Bundle example', function() {
     var builder = new Builder('test/output');
     fs.writeFileSync('./test/output/dynamic-module.js', 'export var p = 5;');


### PR DESCRIPTION
This is a repro for issue (1)  mentioned [here](https://github.com/frankwallis/plugin-typescript/issues/133#issuecomment-231892589) where ```load.metadata.timestamp``` is not being set and so caching is not working.

The calllback method which sets ```load.metadata.timestamp``` is never called in ```builder.loader.fetch``` because of an error [here](https://github.com/systemjs/builder/blob/master/lib/builder.js#L179) 