### PR TITLE
Add compiled outputs data for `bundle`, `buildStatic` methods

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -706,6 +706,7 @@ Builder.prototype.bundle = function(expressionOrTree, outFile, opts) {
         .then(function(output) {
           output.modules = compiled.modules;
           output.entryPoints = compiled.entryPoints;
+          output.outputs = compiled.outputs;
           output.tree = tree;
           output.assetList = compiled.assetList;
           if (outputOpts.outFile) {
@@ -809,6 +810,7 @@ Builder.prototype.buildStatic = function(expressionOrTree, outFile, opts) {
           output.inlineMap = inlineMap;
         output.assetList = compiled.assetList;
         output.modules = compiled.modules;
+        output.outputs = compiled.outputs;
         output.tree = tree;
         return output;        
       });


### PR DESCRIPTION
I've added the additional field `outputs` to the output of `bundle`, `buildStatic` methods. The field contains a sorted array of sources and appropriate source map data before merging them to the single bundle:
![outputs](https://cloud.githubusercontent.com/assets/748074/18583242/0f551ff6-7c12-11e6-9c05-9ed29857c8b9.png)
It allows to add plugins that can build custom bundles based on provided data, e.g. `eval` bundle:
```javascript
eval(
   $__System.register(...);
   //# sourceMappingURL=moduleA.js.map
);
eval(...);
...
eval(...);
```
Here are more examples of different bundles that Webpack uses: [devtool](https://webpack.github.io/docs/configuration.html#devtool)

