### PR TITLE
prevent unnecessary recursion during trace

### DIFF
--- a/lib/trace.js
+++ b/lib/trace.js
@@ -628,6 +628,11 @@ Trace.prototype.getAllLoadRecords = function(canonical, traceOpts, canonicalCond
   var self = this;
   return this.getLoadRecord(canonical, traceOpts, parentStack)
   .then(function(load) {
+
+    // check this again – might have been loaded asynchronously since the last check
+    if (canonical in curLoads)
+      return curLoads;
+
     // conditionals, build: false and system modules are falsy loads in the trace trees
     // (that is, part of depcache, but not built)
     // we skip system modules though


### PR DESCRIPTION
Fixes #701 

The current exit condition is sub-optimal. As the tree of load dependencies is traversed asynchronously, it is possible that the same module's dependencies could be recursed many times. In our case, this was triggering a massive number of promises and crashing node itself.