### PR TITLE
Allow specifying mangle options

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -79,11 +79,15 @@ function minify(output, fileName, mangle, uglifyOpts) {
     throw new Error(e);
   }
   ast.figure_out_scope();
-  
+
   ast = ast.transform(uglify.Compressor(uglifyOpts.compress));
   ast.figure_out_scope();
-  if (mangle !== false)
-    ast.mangle_names();
+  if (mangle !== false) {
+    if(typeof mangle !== 'object') {
+      mangle = {};
+    }
+    ast.mangle_names(mangle);
+  }
 
   var sourceMap;
   if (output.sourceMap) {
@@ -126,7 +130,7 @@ function writeOutputFile(outFile, source, sourceMap) {
 
     var sourceMapFileName = path.basename(outFile) + '.map';
     source += '\n//# sourceMappingURL=' + sourceMapFileName;
-    
+
     return asp(fs.writeFile)(path.resolve(outDir, sourceMapFileName), sourceMap);
   })
   .then(function() {


### PR DESCRIPTION
Uglifyjs supports options passed into the `mangle_names` method: https://github.com/mishoo/UglifyJS2/blob/4761d07e0bc3d4c53e0c9c72fc9c322c95cb090e/lib/scope.js#L394

This PR changes the `mangle` option to optionally take an object and pass options.
