### PR TITLE
workaround for #705

### DIFF
--- a/lib/rollup.js
+++ b/lib/rollup.js
@@ -259,7 +259,8 @@ exports.rollupTree = function(loader, tree, entryPoints, traceOpts, compileOpts,
 
       var generateOptions = {
         sourceMap: compileOpts.sourceMaps,
-        exports: defaultExport ? 'default' : 'named'
+        exports: defaultExport ? 'default' : 'named',
+        dest: 'output.js' // workaround for rollup/rollup#1015
       };
 
       // for a full tree rollup, we pass all the output options into rollup itself


### PR DESCRIPTION
Pass `dest` option to rollup bundle to make it convert absolute paths to relative
workaround for rollup/rollup#1015