### PR TITLE
Fix Rollup + sourceMapContents: Mismatched sourcesContent

### DIFF
--- a/compilers/esm.js
+++ b/compilers/esm.js
@@ -118,7 +118,7 @@ exports.compile = function(load, opts, loader) {
       output.code = output.code.replace(/(\s|^)System\.register\(/, '$1' + opts.systemGlobal + '.register(');
 
     // for some reason Babel isn't respecting sourceFileName...
-    if (output.map)
+    if (output.map && !load.metadata.sourceMap)
       output.map.sources[0] = load.path;
 
     return Promise.resolve({


### PR DESCRIPTION
This fixes #678.

In `compilers/esm.js` [L121](https://github.com/systemjs/builder/blob/master/compilers/esm.js#L121), a workaround had been introduced for Babel not respecting the `sourceFileName` option:

```
    // for some reason Babel isn't respecting sourceFileName...
    if (output.map && !load.metadata.sourceMap)
      output.map.sources[0] = load.path;
```

However, I believe that this option is not meant to be used along with `inputSourceMap`, as in the later case the original source file names are already embedded in the provided sourcemap, whereas `sourceFileName` is designed to provide the original file name when Babel is the entry point of the build pipeline (and the code is provided as a string and not a path).

The corresponding `sourceMapContent` test seems broken at the moment, hence no tests in the PR :(
