### PR TITLE
pass "compact" option to esm compiler based on systemjs configuration

### DIFF
--- a/compilers/esm.js
+++ b/compilers/esm.js
@@ -7,6 +7,7 @@ var createStringLiteralToken = traceurGet('codegeneration/ParseTreeFactory.js').
 var InstantiateModuleTransformer = traceurGet('codegeneration/InstantiateModuleTransformer.js').InstantiateModuleTransformer;
 
 var extend = require('../lib/utils').extend;
+var pick = require('../lib/utils').pick;
 
 // patch pending https://github.com/google/traceur-compiler/pull/2053
 var createUseStrictDirective = traceurGet('codegeneration/ParseTreeFactory.js').createUseStrictDirective;
@@ -45,6 +46,16 @@ function remap(source, map, fileName) {
 }
 exports.remap = remap;
 
+function getBabelDefaultOptions(loader, load) {
+  var props = ['compact'];
+
+  var options = {};
+  extend(options, pick(loader.babelOptions, props));
+  extend(options, pick(load.metadata.babelOptions, props));
+
+  return options;
+}
+
 // override System instantiate to handle esm tracing
 exports.attach = function(loader) {
   var systemInstantiate = loader.instantiate;
@@ -55,8 +66,10 @@ exports.attach = function(loader) {
 
     var depsList = load.metadata.deps.concat([]);
 
+    var babelDefaultOptions = getBabelDefaultOptions(loader, load);
+
     var babel = require('babel-core');
-    var output = babel.transform(load.source, {
+    var output = babel.transform(load.source, extend(babelDefaultOptions, {
       babelrc: false,
       filename: load.path,
       //sourceFileName: load.path,
@@ -67,7 +80,7 @@ exports.attach = function(loader) {
           depsList.push(dep);
         return dep;
       }
-    });
+    }));
     // turn back on comments (for some reason!)
     output.ast.comments.forEach(function(comment) {
       comment.ignore = false;
@@ -87,7 +100,9 @@ exports.compile = function(load, opts, loader) {
   if (!load.metadata.originalSource || load.metadata.loader && load.metadata.format == 'esm') {
     var babel = require('babel-core');
 
-    var babelOptions = {
+    var babelDefaultOptions = getBabelDefaultOptions(loader, load);
+
+    var babelOptions = extend(babelDefaultOptions, {
       babelrc: false,
       plugins: [[require('babel-plugin-transform-es2015-modules-systemjs'), { systemGlobal: opts.systemGlobal }]],
       filename: load.path,
@@ -103,7 +118,7 @@ exports.compile = function(load, opts, loader) {
         else
           return dep;
       }
-    };
+    });
 
     var source = load.metadata.originalSource || load.source;
 
@@ -175,16 +190,16 @@ exports.compile = function(load, opts, loader) {
       if (options.target === undefined)
         options.target = transpiler.ScriptTarget.ES5;
       options.module = transpiler.ModuleKind.System;
-      
-      var transpileOptions = { 
-        compilerOptions: options, 
-        renamedDependencies: load.depMap, 
-        fileName: load.path, 
-        moduleName: !opts.anonymous && load.name 
+
+      var transpileOptions = {
+        compilerOptions: options,
+        renamedDependencies: load.depMap,
+        fileName: load.path,
+        moduleName: !opts.anonymous && load.name
       };
-      
+
       var transpiled = transpiler.transpileModule(load.source, transpileOptions);
-      
+
       return Promise.resolve({
         source: transpiled.outputText,
         sourceMap: transpiled.sourceMapText
@@ -197,7 +212,7 @@ exports.compile = function(load, opts, loader) {
           console.log('Warning - using Babel ' + babelVersion + '. This version of SystemJS builder is designed to run against Babel 5.');
         versionCheck = false;
       }
-        
+
       var options = extend({}, loader.babelOptions || {});
       options.modules = 'system';
       if (opts.sourceMaps)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -28,6 +28,18 @@ function dextend(a, b) {
   return a;
 }
 
+exports.pick = pick;
+function pick(obj, props) {
+  var result = {};
+  for (var index in props) {
+    var prop = props[index];
+    if (typeof obj === 'object' && prop in obj) {
+      result[prop] = obj[prop];
+    }
+  }
+  return result;
+}
+
 exports.getFormatHint = getFormatHint;
 function getFormatHint(compileOpts) {
   var formatHint = '';
@@ -96,7 +108,7 @@ function getAlias(loader, canonicalName) {
       bestAliasSubpath = '';
       bestAliasLength = alias.split('/').length;
     }
-    else if (canonicalName.substr(0, mapped.length) == mapped && 
+    else if (canonicalName.substr(0, mapped.length) == mapped &&
         (canonicalName.length == mapped.length || canonicalName[mapped.length] == '/')) {
       bestAlias = alias;
       bestAliasSubpath = canonicalName.substr(mapped.length);
@@ -189,7 +201,7 @@ function getCanonicalNamePlain(loader, normalized, isPlugin) {
 
     // support trailing / in paths rules
     else if (curPath[curPath.length - 1] == '/' &&
-        normalized.substr(0, curPath.length - 1) == curPath.substr(0, curPath.length - 1) && 
+        normalized.substr(0, curPath.length - 1) == curPath.substr(0, curPath.length - 1) &&
         (normalized.length < curPath.length || normalized[curPath.length - 1] == curPath[curPath.length - 1])) {
       // first case is that canonicalize('src') = 'app' for 'app/': 'src/'
       return normalized.length < curPath.length ? p.substr(0, p.length - 1) : p + normalized.substr(curPath.length);


### PR DESCRIPTION
Pass "compact" option to esm compiler based on systemjs configuration.
This allows to create non minified development builds for applications larger than 100kb.
Code is easy to fix to pass other options besides "compact"