### PR TITLE
Fixing #734. Not using 'require' if process.browser is set to true

### DIFF
--- a/templates/sfx-core.js
+++ b/templates/sfx-core.js
@@ -367,7 +367,7 @@
     entry.module.execute.call(global);
   }
 
-  var nodeRequire = typeof System != 'undefined' && System._nodeRequire || typeof process != 'undefined' && !process.browser && typeof require != 'undefined' && typeof require.resolve != 'undefined' && require;
+  var nodeRequire = typeof System != 'undefined' && System._nodeRequire || typeof require != 'undefined' && typeof require.resolve != 'undefined' && typeof process != 'undefined' && process.platform && require;
 
   // magical execution function
   var modules = { '@empty': {} };

--- a/templates/sfx-core.js
+++ b/templates/sfx-core.js
@@ -367,7 +367,7 @@
     entry.module.execute.call(global);
   }
 
-  var nodeRequire = typeof System != 'undefined' && System._nodeRequire || typeof require != 'undefined' && require.resolve && typeof process != 'undefined' && require;
+  var nodeRequire = typeof System != 'undefined' && System._nodeRequire || typeof process != 'undefined' && !process.browser && typeof require != 'undefined' && typeof require.resolve != 'undefined' && require;
 
   // magical execution function
   var modules = { '@empty': {} };


### PR DESCRIPTION
See https://github.com/systemjs/builder/issues/734. In that issue, there are two related problems described: (1) webpack warnings, and (2) runtime error. This pull request will reduce the number of webpack warnings from two to one, and it will eliminate the runtime error. Afaik, getting rid of that last webpack warning would only be possible if we do not store System._nodeRequire, which does not seem like a likely option.

Let me know if there's something better to do here to fix the problem; I'm only about 50%-75% sure that this is a good way to resolve the issue.

Also note that this would fix https://github.com/CanopyTax/single-spa/issues/79