### PR TITLE
fixed inline source maps

### DIFF
--- a/compilers/compiler.js
+++ b/compilers/compiler.js
@@ -16,7 +16,7 @@ exports.compile = function (load, opts, plugin) {
     inputSourceMap: load.metadata.sourceMap,
     moduleId: opts.moduleId,
     sourceFileName: path.basename(load.path),
-    sourceMaps: opts.sourceMaps,
+    sourceMaps: !!opts.sourceMaps,
     sourceRoot: sourceRoot,
     plugins: [plugin]
   };

--- a/test/sourcemaps.js
+++ b/test/sourcemaps.js
@@ -65,7 +65,7 @@ suite('Source Maps', function() {
   suiteSetup(writeTestOutput);
 
   test('can render inline', function(done) {
-    var module = 'amd-2.js';
+    var module = 'amd-2.js + cjs.js';
 
     var instance = new Builder();
     instance.loadConfigSync(configFile);
@@ -80,9 +80,9 @@ suite('Source Maps', function() {
       assert(lastLine.match(commentPrefix));
       var encoding = lastLine.replace(commentPrefix, "");
       var decoded = JSON.parse(atob(encoding));
-      // not a regular array so tedious
-      assert.equal(1, decoded.sources.length);
-      assert.equal('test/fixtures/test-tree/amd-2.js', decoded.sources[0]);
+      assert.deepEqual(decoded.sources,
+        [ "test/fixtures/test-tree/amd-2.js",
+          "test/fixtures/test-tree/cjs.js" ]);
     })
     .then(done)
     .catch(err);


### PR DESCRIPTION
Fixes `{ sourceMaps: 'inline' }` case. Babel was unnecessarily adding inline source maps to the output - instead it should add them to the metadata.