### PR TITLE
Fix { sourceMaps: 'inline' } option; fixes #754

### DIFF
--- a/compilers/esm.js
+++ b/compilers/esm.js
@@ -94,7 +94,7 @@ exports.compile = function(load, opts, loader) {
       plugins: [[require('babel-plugin-transform-es2015-modules-systemjs'), { systemGlobal: opts.systemGlobal }]],
       filename: load.path,
       //sourceFileName: load.path,
-      sourceMaps: opts.sourceMaps,
+      sourceMaps: !!opts.sourceMaps,
       inputSourceMap: load.metadata.sourceMap,
       moduleIds: !opts.anonymous,
       moduleId: !opts.anonymous && load.name,

--- a/lib/rollup.js
+++ b/lib/rollup.js
@@ -258,7 +258,7 @@ exports.rollupTree = function(loader, tree, entryPoints, traceOpts, compileOpts,
         defaultExport = true;
 
       var generateOptions = {
-        sourceMap: compileOpts.sourceMaps,
+        sourceMap: !!compileOpts.sourceMaps,
         exports: defaultExport ? 'default' : 'named',
         dest: 'output.js' // workaround for rollup/rollup#1015
       };


### PR DESCRIPTION
Resolves issue where only source maps of `jspm_packages` were being included when building `{ sourceMaps: 'inline' }` option.