### PR TITLE
Uglify Upgrade

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -82,7 +82,7 @@ function minify(output, fileName, options) {
       compress: options.uglify.compress,
       mangle: options.mangle,
       output: {
-        beautify: options.uglify.beautify
+        ascii_only: options.uglify.beautify.ascii_only
       },
       warnings: options.uglify.compress.warnings
     };

--- a/lib/output.js
+++ b/lib/output.js
@@ -71,48 +71,33 @@ function createOutput(outFile, outputs, basePath, sourceMaps, sourceMapContents)
   };
 }
 
-function minify(output, fileName, mangle, uglifyOpts) {
-  var uglify = require('uglify-js');
-  var ast;
-  try{
-    ast = uglify.parse(output.source, { filename: fileName });
-  } catch(e){
-    throw new Error(e);
-  }
-  ast.figure_out_scope();
-  
-  ast = ast.transform(uglify.Compressor(uglifyOpts.compress));
-  ast.figure_out_scope();
-  if (mangle !== false)
-    ast.mangle_names();
+function minify(output, fileName, options) {
+  var uglify = require('uglify-es');
 
-  var sourceMap;
+  var files = {};
+  files[fileName] = output.source;
+
+  var minifyOpt = options.uglifyes
+    || {
+      compress: options.uglify.compress,
+      mangle: options.mangle,
+      output: {
+        beautify: options.uglify.beautify
+      },
+      warnings: options.uglify.compress.warnings
+    };
+
   if (output.sourceMap) {
-    if (typeof output.sourceMap === 'string')
-      output.sourceMap = JSON.parse(output.sourceMap);
-
-    var sourceMapIn = output.sourceMap;
-    sourceMap = uglify.SourceMap({
-      file: fileName,
-      orig: sourceMapIn
-    });
-
-    if (uglifyOpts.sourceMapIncludeSources && sourceMapIn && Array.isArray(sourceMapIn.sourcesContent)) {
-      sourceMapIn.sourcesContent.forEach(function(content, idx) {
-        sourceMap.get().setSourceContent(sourceMapIn.sources[idx], content);
-      });
+    minifyOpt.sourceMap = {
+      content: output.sourceMap,
+      url: fileName + ".map"
     }
   }
 
-  var outputOptions = uglifyOpts.beautify;
-  // keep first comment
-  outputOptions.comments = outputOptions.comments || function(node, comment) {
-    return comment.line === 1 && comment.col === 0;
-  };
-  outputOptions.source_map = sourceMap;
+  var result = uglify.minify(files, minifyOpt);
 
-  output.source = ast.print_to_string(outputOptions);
-  output.sourceMap = sourceMap;
+  output.source = result.code;
+  output.sourceMap = result.map;
 
   return output;
 }
@@ -151,7 +136,7 @@ exports.writeOutputs = function(outputs, baseURL, outputOpts) {
   var output = createOutput(outFile || path.resolve(basePath, fileName), outputs, basePath, outputOpts.sourceMaps, outputOpts.sourceMapContents);
 
   if (outputOpts.minify)
-    output = minify(output, fileName, outputOpts.mangle, outputOpts.uglify);
+    output = minify(output, fileName, outputOpts);
 
   if (outputOpts.sourceMaps == 'inline') {
     output.source = inlineSourceMap(output.source, output.sourceMap);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "source-map": "^0.5.3",
     "systemjs": "^0.19.43",
     "traceur": "0.0.105",
-    "uglify-js": "~2.7.5"
+    "uglify-es": "https://github.com/mishoo/UglifyJS2#harmony"
   },
   "devDependencies": {
     "babel": "^5.8.38",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systemjs-builder",
-  "version": "0.15.35",
+  "version": "0.15.36",
   "description": "SystemJS Build Tool",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "source-map": "^0.5.3",
     "systemjs": "^0.19.43",
     "traceur": "0.0.105",
-    "uglify-js": "^2.6.1"
+    "uglify-js": "~2.7.5"
   },
   "devDependencies": {
     "babel": "^5.8.38",


### PR DESCRIPTION
This is an initial stab but needs more work. 

Now I'm looking through the code I realise the options merging/transformations should really be happening in `processOutputOpts` but there is quite a bit of legacy stuff in there without tests so I'll need to be careful not to break anything.

It should support the existing config options:
```
builder.bundle('myModule.js', 'outfile.js', { minify: true, mangle: false, uglify: uglifyOps  });
```
Or you can pass the entire uglify-es valid config in yourself through `options.uglifyes`:
```
var uglifyOpt = { 
    compress: {
        global_defs: { DEBUG: false },
        dead_code: true,
    },
    mangle: false,
    warnings: false 
}
builder.bundle('myModule.js', 'outfile.js', { minify: true, uglifyes: uglifyOpt });
```