### PR TITLE
Add uglify.output Option in Build

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -596,8 +596,9 @@ function processOutputOpts(options, defaults) {
   extend(opts, options);
 
   opts.uglify = opts.uglify || {};
+  opts.uglify.output   = opts.uglify.output || {};
   opts.uglify.compress = opts.uglify.compress || {};
-  opts.uglify.beautify = opts.uglify.beautify || {};
+  opts.uglify.beautify = opts.uglify.beautify || opts.uglify.output;
 
   // NB deprecated these for uglify directly
   if (opts.globalDefs && !('global_defs' in opts.uglify.compress))


### PR DESCRIPTION
`uglify` option in `build` now accepts `uglify.output` consistent with the Uglify2 API.

This change does NOT change existing behaviour as the inconsistent `uglify.beautify` is still valid. Internally `uglify.output` is copied into `uglify.beautify`, when the latter is not specified. If `uglify.beautify` is specified, then `uglify.output` is ignored.