### PR TITLE
Fix missing path normalization, causing empty sourcesContent in source maps.

### DIFF
--- a/lib/sourcemaps.js
+++ b/lib/sourcemaps.js
@@ -45,7 +45,7 @@ exports.concatenateSourceMaps = function(outFile, mapsWithOffsets, basePath, sou
 
     if (sourceMapContents && map.sourcesContent) {
       for (var i=0; i<map.sources.length; i++) {
-        var source = path.posix.normalize(map.sources[i].startsWith("/") ? map.sources[i] : (map.sourceRoot || '') + map.sources[i]);
+        var source = path.normalize(path.isAbsolute(map.sources[i]) ? map.sources[i] : (map.sourceRoot || '') + map.sources[i]).replace(/\\/g, '/');
         if (!source.match(/\/@traceur/)) {
           if (!contentsBySource[source]) {
             contentsBySource[source] = map.sourcesContent[i];
@@ -98,7 +98,7 @@ exports.concatenateSourceMaps = function(outFile, mapsWithOffsets, basePath, sou
     if (isFileURL(source))
       source = fromFileURL(source);
 
-    return path.relative(outPath, path.resolve(basePath, source)).replace(/\\/g, '/');
+    return path.isAbsolute(source) ? source : path.relative(outPath, path.resolve(basePath, source)).replace(/\\/g, '/');
   });
 
   return JSON.stringify(normalized);

--- a/lib/sourcemaps.js
+++ b/lib/sourcemaps.js
@@ -45,7 +45,7 @@ exports.concatenateSourceMaps = function(outFile, mapsWithOffsets, basePath, sou
 
     if (sourceMapContents && map.sourcesContent) {
       for (var i=0; i<map.sources.length; i++) {
-        var source = (map.sourceRoot || '') + map.sources[i];
+        var source = path.posix.normalize(map.sources[i].startsWith("/") ? map.sources[i] : (map.sourceRoot || '') + map.sources[i]);
         if (!source.match(/\/@traceur/)) {
           if (!contentsBySource[source]) {
             contentsBySource[source] = map.sourcesContent[i];


### PR DESCRIPTION
If source maps already exist for the files being bundled, and if those source maps have their "sourceRoot" set to anything other than an empty string (such as "/" or "../"), then the builder fails to include the original source content in the source map for the bundle.

This happens because line 48 in sourcemaps.js fails to take into account that the source path may already be absolute, or if is relative, that it needs to be normalized.

This lack of normalization becomes a problem in line 85, where the source map itself has been normalized, while the keys for which the source content were stored are still the non-normalized paths - and therefore, the original content is not found. When it then tries to load the content from the original source file, it fails again if the original source maps had its "sourceRoot" set to an absolute path, as map.sourceRoot would then have been incorrectly prepended to the path.

This pull request fixes this, so if the path is already absolute, it is used as-is, and and if it is relative, it is normalized. This means source content is now correctly loaded from existing sourcemaps and included in the source map for the bundle - or if the original source maps do not contain the content, correctly loaded from the original source files.