### PR TITLE
Fix incorrect source path normalization, when the path is a file URL on a non-Windows system

### DIFF
--- a/lib/sourcemaps.js
+++ b/lib/sourcemaps.js
@@ -105,14 +105,16 @@ exports.concatenateSourceMaps = function(outFile, mapsWithOffsets, basePath, sou
   }
 
   normalized.sources = normalized.sources.map(function(source) {
+    var isRootRelative = /^[\\/]/.test(source);
+
     if (isFileURL(source))
       source = fromFileURL(source);
 
-    // If the source is already a root-relative path, use it as-is, otherwise make it relative to the outPath.
-    var isRootRelative = /^[\\/]/.test(source);
-    source = (isRootRelative ? source : path.relative(outPath, path.resolve(basePath, source))).replace(/\\/g, '/');
+    // If the source is not already a root-relative path, make it relative to the outPath.
+    if (!isRootRelative)
+      source = path.relative(outPath, path.resolve(basePath, source));
 
-    return source;
+    return source.replace(/\\/g, '/');
   });
 
   return JSON.stringify(normalized);


### PR DESCRIPTION
The utility function `fromFileURL` seem to have an inconsistent behavior, where it removes the leading `/` from the path when running on Windows, but not when running on a non-Windows system.

This inconsistency caused the issue reported in https://github.com/jspm/jspm-cli/issues/2361#issuecomment-350192381, where the source paths were only made relative to the `outPath` when building on a Windows system, thus resulting in full file system paths in source maps built on non-Windows systems.

This pull request fixes this bug.

Note that this fix is specifically to restore the correct behavior for source paths - it makes no attempt to fix the inconsistent behavior in the `fromFileURL` function, as the consequences of doing so are unclear.