### PR TITLE
Use terser (uglify-js fork) to support minification of more permissive babel presets

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -4,9 +4,21 @@ var fs = require('fs');
 var Promise = require('bluebird');
 var asp = require('bluebird').promisify;
 var extend = require('./utils').extend;
+var terser = require('terser');
 
 var fromFileURL = require('./utils').fromFileURL;
 var toFileURL = require('./utils').toFileURL;
+
+// Ugly hack to get around terser's strange code loading and export system
+// (inherited from uglify-js), and the fact that their SourceMap wrapper is
+// not exported
+var TerserSourceMap = new Function('MOZ_SourceMap', "exports", "require", function() {
+  var code = ['terser/lib/utils.js', 'terser/lib/sourcemap.js'].map(function(file) {
+    return fs.readFileSync(require.resolve(file), 'utf8');
+  });
+  code.push('return SourceMap;');
+  return code.join('\n');
+}())(require('source-map'), terser, require);
 
 function countLines(str) {
   return str.split(/\r\n|\r|\n/).length;
@@ -72,36 +84,35 @@ function createOutput(outFile, outputs, basePath, sourceMaps, sourceMapContents)
 }
 
 function minify(output, fileName, mangle, uglifyOpts) {
-  var uglify = require('uglify-js');
-  var ast;
+  var files = {};
+  files[fileName] = output.source;
+  var result;
   try{
-    ast = uglify.parse(output.source, { filename: fileName });
+    result = terser.minify(files, {
+      parse: {},
+      compress: uglifyOpts.compress,
+      mangle: mangle,
+      output: { ast: true, code: false }
+    });
   } catch(e){
     throw new Error(e);
   }
-  ast.figure_out_scope();
-  
-  ast = ast.transform(uglify.Compressor(uglifyOpts.compress));
-  ast.figure_out_scope();
-  if (mangle !== false)
-    ast.mangle_names();
+
+  if (result.error) {
+    throw new Error(result.error);
+  }
+
+  var ast = result.ast;
 
   var sourceMap;
   if (output.sourceMap) {
     if (typeof output.sourceMap === 'string')
       output.sourceMap = JSON.parse(output.sourceMap);
 
-    var sourceMapIn = output.sourceMap;
-    sourceMap = uglify.SourceMap({
+    sourceMap = TerserSourceMap({
       file: fileName,
-      orig: sourceMapIn
+      orig: output.sourceMap
     });
-
-    if (uglifyOpts.sourceMapIncludeSources && sourceMapIn && Array.isArray(sourceMapIn.sourcesContent)) {
-      sourceMapIn.sourcesContent.forEach(function(content, idx) {
-        sourceMap.get().setSourceContent(sourceMapIn.sources[idx], content);
-      });
-    }
   }
 
   var outputOptions = uglifyOpts.beautify;

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "rollup": "^0.58.2",
     "source-map": "^0.5.3",
     "systemjs": "^0.19.46",
-    "traceur": "0.0.105",
-    "uglify-js": "^2.6.1"
+    "terser": "^3.8.1",
+    "traceur": "0.0.105"
   },
   "devDependencies": {
     "babel": "^5.8.38",

--- a/test/arithmetic.js
+++ b/test/arithmetic.js
@@ -37,7 +37,7 @@ suite('Bundle Expressions', function() {
     .then(function(tree) {
       assert.deepEqual(Object.keys(tree).sort(), [
           'Buffer.js', 'amd.js', 'babel', 'babel.js', 'cjs space.js', 'cjs-1.js', 'cjs-2.js', 'cjs-3.js', 'cjs-4.js', 'cjs-5.js', 'cjs-globals.js', 'cjs-in-12.js', 'cjs-in-13.js',
-          'cjs-resolve.js', 'cjs.js', 'component.jsx!jsx.js', 'example.js', 'file.json', 'first.js',
+          'cjs-resolve.js', 'cjs.js', 'class-def.js', 'component.jsx!jsx.js', 'example.js', 'file.json', 'first.js',
           'global-inner.js', 'global-outer.js', 'global.js', 'jquery-cdn', 'jquery.js', 'json-plugin.js', 'jsx.js', 'plugin.js', 'register.js', 'runtime.js', 
           'second.js', 'some.js!plugin.js', 'text-plugin.js', 'text.txt!text-plugin.js', 'third.js', 'umd.js']);
     })

--- a/test/fixtures/test-tree/class-def.js
+++ b/test/fixtures/test-tree/class-def.js
@@ -1,0 +1,13 @@
+class Foo {
+  constructor() {
+    this.bar = 'bar';
+  }
+  static get baz() { return 'baz'; }
+}
+
+const foo = new Foo();
+
+module.exports = {
+  foo: foo,
+  barbaz: `${foo.bar}${Foo.baz}`,
+};

--- a/test/test-build.js
+++ b/test/test-build.js
@@ -243,3 +243,21 @@ suite('Bundle Format', function() {
     });
   });
 });
+
+suite('Test ES6 minification', function() {
+  test('ES6 syntax minify, unmangled', function() {
+    builder.reset();
+    return builder.bundle('class-def.js', { minify: true , mangle: false })
+    .then(function(output) {
+      assert.match(output.source, /class Foo{constructor\(\){/, 'source contains literal class');
+    });
+  });
+
+  test('ES6 syntax minify, mangled', function() {
+    builder.reset();
+    return builder.bundle('class-def.js', { minify: true , mangle: true })
+    .then(function(output) {
+      assert.match(output.source, /class \w{constructor\(\){/, 'source contains literal class, mangled');
+    });
+  });
+});

--- a/test/test-sfx.html
+++ b/test/test-sfx.html
@@ -6,12 +6,11 @@
     <div id="mocha">
   <script>
     window.$ = { jquery: 1 };
+    window.DEBUG = false;
   </script>
   <script src="output/sfx.js"></script>
   <script>
     mocha.setup('tdd');
-
-    DEBUG = false;
 
     function assert(assertion, msg) {
       if (!assertion)


### PR DESCRIPTION
Currently, only ES5 javascript can be minified, due to the reliance on uglify-js. Terser is the actively maintained fork of what used to be uglify-es, the harmony branch for uglify-js@3. By using terse the systemjs builder is able to support a broader range of ECMAScript syntax.

There were significant API changes between uglify-js@2 and uglify-js@3, and so also with terser, but the updates required in the systemjs builder minify function were fairly straightforward. This PR hews more closely to the original code than #815 does, and consequently I think it avoids regressing any features (for instance, the ability to include sourceContents in source maps or to control the comment stripping is retained).

As browsers continue to support more features beyond ES5, and because babel recommends use of the 'env' preset, it will become increasingly likely that users' babel transpilation settings will cause errors when trying to minify with jspm and friends.

As part of this PR I've added a test suite that fails before this fix and passes afterwards.

refs #815, #726 
